### PR TITLE
Fix cookie name not in rule from school api response error

### DIFF
--- a/lib/src/connector/interceptors/response_cookie_filter.dart
+++ b/lib/src/connector/interceptors/response_cookie_filter.dart
@@ -1,0 +1,38 @@
+// 🎯 Dart imports:
+import 'dart:io';
+
+// 📦 Package imports:
+import 'package:dio/dio.dart';
+import 'package:meta/meta.dart';
+
+/// A cookie filter that can assist in excluding certain cookies from the response.
+@immutable
+@protected
+@sealed
+class ResponseCookieFilter extends Interceptor {
+  /// The filtering adopts the blacklist mechanism,
+  /// and the cookie name or part of the name that needs to be removed is passed in
+  /// through [blockedCookieNamePatterns].
+  ResponseCookieFilter({@required List<RegExp> blockedCookieNamePatterns})
+      : _blockedCookieNamePatterns = blockedCookieNamePatterns;
+
+  final List<RegExp> _blockedCookieNamePatterns;
+
+  @override
+  Future onResponse(Response response) async {
+    try {
+      return _removeCookiesFrom(response);
+    } on Exception catch (e) {
+      return DioError(request: response.request, error: e);
+    }
+  }
+
+  Response _removeCookiesFrom(Response response) {
+    final cookies = response.headers[HttpHeaders.setCookieHeader]
+        ?.where((cookie) => _blockedCookieNamePatterns.every((pattern) => !pattern.hasMatch(cookie)))
+        ?.toList();
+
+    if (cookies != null) response.headers.set(HttpHeaders.setCookieHeader, cookies);
+    return response;
+  }
+}


### PR DESCRIPTION
## Description
I don't know when it started, the back end of the school added a cookie to the response header, its name style is `BIGipServerVPFl/xxxxxxxxxxxxxxx`, and in this name, there are characters that do not meet the requirements, which will cause dio parsing errors, so it needs to be filtered out .
So, I added a blacklist filter repeater that allows us to filter out these weird cookie names by providing a regexp.