### PR TITLE
Fix: storage permission check wrong

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:name=".Application"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         android:label="TAT"
         tools:targetApi="m">
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -184,7 +184,7 @@ PODS:
     - Flutter
   - path_provider (0.0.1):
     - Flutter
-  - "permission_handler (5.0.1+1)":
+  - "permission_handler (5.1.0+2)":
     - Flutter
   - PromisesObjC (1.2.12)
   - Reachability (3.2)
@@ -364,7 +364,7 @@ SPEC CHECKSUMS:
   open_file: 02eb5cb6b21264bd3a696876f5afbfb7ca4f4b7d
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
-  permission_handler: eac8e15b4a1a3fba55b761d19f3f4e6b005d15b6
+  permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SDWebImage: b969dcfc02c40a5da71eac0b03b8f1a0c794a86f

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -675,6 +675,26 @@ class S {
     );
   }
 
+  /// `Changing password...`
+  String get changingPassword {
+    return Intl.message(
+      'Changing password...',
+      name: 'changingPassword',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Changing password Error`
+  String get changingPasswordError {
+    return Intl.message(
+      'Changing password Error',
+      name: 'changingPasswordError',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Check identity`
   String get checkIdentity {
     return Intl.message(

--- a/lib/src/file/FileStore.dart
+++ b/lib/src/file/FileStore.dart
@@ -30,7 +30,14 @@ class FileStore {
     final directory = await _getFilePath() ?? Platform.isAndroid
         ? await getExternalStorageDirectory()
         : await getApplicationSupportDirectory();
-    return directory.path;
+
+    final targetDir = Directory(directory.path + '/TAT');
+    final hasExisted = await targetDir.exists();
+    if (!hasExisted) {
+      targetDir.create();
+    }
+
+    return targetDir.path;
   }
 
   static Future<String> getDownloadDir(BuildContext context, String name) async {

--- a/lib/src/file/FileStore.dart
+++ b/lib/src/file/FileStore.dart
@@ -20,7 +20,7 @@ class FileStore {
   static String storeKey = "downloadPath";
 
   static Future<String> findLocalPath(BuildContext context) async {
-    bool checkPermission = await PermissionsUtil.check(context);
+    bool checkPermission = await PermissionsUtil.checkHasAosStoragePermission(context);
     if (!checkPermission) {
       MyToast.show(R.current.noPermission);
       return "";

--- a/lib/src/file/FileStore.dart
+++ b/lib/src/file/FileStore.dart
@@ -6,6 +6,7 @@
 //  Copyright © 2020 morris13579 All rights reserved.
 //
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
@@ -17,51 +18,50 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class FileStore {
-  static String storeKey = "downloadPath";
+  static const storeKey = "downloadPath";
 
   static Future<String> findLocalPath(BuildContext context) async {
-    bool checkPermission = await PermissionsUtil.checkHasAosStoragePermission(context);
-    if (!checkPermission) {
+    final hasStoragePermission = await PermissionsUtil.checkHasAosStoragePermission(context);
+    if (!hasStoragePermission) {
       MyToast.show(R.current.noPermission);
-      return "";
+      return '';
     }
-    Directory directory = await _getFilePath();
-    if (directory == null) {
-      directory = Theme.of(context).platform == TargetPlatform.android
-          ? await getExternalStorageDirectory()
-          : await getApplicationSupportDirectory();
-    }
+
+    final directory = await _getFilePath() ?? Platform.isAndroid
+        ? await getExternalStorageDirectory()
+        : await getApplicationSupportDirectory();
     return directory.path;
   }
 
-  static Future<String> getDownloadDir(
-      BuildContext context, String name) async {
-    var _localPath = (await findLocalPath(context)) + '/$name';
+  static Future<String> getDownloadDir(BuildContext context, String name) async {
+    final _localPath = (await findLocalPath(context)) + '/$name';
     final savedDir = Directory(_localPath);
-    bool hasExisted = await savedDir.exists();
+    final hasExisted = await savedDir.exists();
+
     if (!hasExisted) {
       savedDir.create();
     }
+
     return savedDir.path;
   }
 
   static Future<bool> setFilePath(String directory) async {
     if (directory != null) {
-      SharedPreferences pref = await SharedPreferences.getInstance();
-      pref.setString(storeKey, directory);
+      final pref = await SharedPreferences.getInstance();
+      pref.setString(storeKey, base64Encode(directory.codeUnits));
       return true;
-    } else {
-      return false;
     }
+
+    return false;
   }
 
   static Future<Directory> _getFilePath() async {
-    SharedPreferences pref = await SharedPreferences.getInstance();
-    String path = pref.getString(storeKey);
+    final pref = await SharedPreferences.getInstance();
+    final path = pref.getString(storeKey);
     if (path != null && path.isNotEmpty) {
-      return Directory(path);
-    } else {
-      return null;
+      return Directory(base64Decode(path).toString());
     }
+
+    return null;
   }
 }

--- a/lib/src/util/PermissionsUtil.dart
+++ b/lib/src/util/PermissionsUtil.dart
@@ -1,32 +1,25 @@
-//
-//  PermissionsUtil.dart
-//  北科課程助手
-//
-//  Created by morris13579 on 2020/02/12.
-//  Copyright © 2020 morris13579 All rights reserved.
-//
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 class PermissionsUtil {
-  static Future<bool> check(BuildContext context) async {
-    // 先對所在平台進行判斷
-    if (Theme.of(context).platform == TargetPlatform.android) {
-      PermissionStatus permission = await Permission.storage.status;
-      if (permission != PermissionStatus.granted) {
-        Map<Permission, PermissionStatus> permissions = await [
-          Permission.storage,
-        ].request();
-        if (permissions[Permission.storage] == PermissionStatus.granted) {
-          return true;
-        }
-      } else {
-        return true;
-      }
-    } else {
-      return true;
+  /// Checks if the APP can access to the file sys on the current device.
+  ///
+  /// If it can not access to, an External Storage (id = 15) warning will occurred.
+  /// So please check if the androidManifest.xml has the following permission declarations:
+  /// - uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+  /// - uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+  static Future<bool> checkHasAosStoragePermission(BuildContext context) async {
+    if (!Platform.isIOS) return true;
+    assert(Platform.isAndroid, 'The platform most be either aos or ios.');
+
+    final storagePermissionStatus = await Permission.storage.status;
+    if (storagePermissionStatus != PermissionStatus.granted) {
+      final requestedPermissions = await [Permission.storage].request();
+      return requestedPermissions[Permission.storage] == PermissionStatus.granted;
     }
-    return false;
+
+    return true;
   }
 }

--- a/lib/src/util/PermissionsUtil.dart
+++ b/lib/src/util/PermissionsUtil.dart
@@ -11,7 +11,7 @@ class PermissionsUtil {
   /// - uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
   /// - uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
   static Future<bool> checkHasAosStoragePermission(BuildContext context) async {
-    if (!Platform.isIOS) return true;
+    if (Platform.isIOS) return true;
     assert(Platform.isAndroid, 'The platform most be either aos or ios.');
 
     final storagePermissionStatus = await Permission.storage.status;

--- a/lib/ui/pages/fileviewer/FileViewerPage.dart
+++ b/lib/ui/pages/fileviewer/FileViewerPage.dart
@@ -20,7 +20,7 @@ class FileViewerPage extends StatefulWidget {
   final String title;
   final String path;
 
-  FileViewerPage({
+  const FileViewerPage({
     Key key,
     @required this.title,
     @required this.path,
@@ -30,11 +30,9 @@ class FileViewerPage extends StatefulWidget {
   _FileViewerPageState createState() => _FileViewerPageState();
 }
 
-class _FileViewerPageState extends State<FileViewerPage>
-    with WidgetsBindingObserver {
+class _FileViewerPageState extends State<FileViewerPage> with WidgetsBindingObserver {
   String path;
-  List<String> paths = List();
-
+  final List<String> paths = List();
   List<FileSystemEntity> files = List();
   bool showHidden = false;
 
@@ -50,8 +48,7 @@ class _FileViewerPageState extends State<FileViewerPage>
     List<FileSystemEntity> l = dir.listSync();
     files.clear();
     setState(() {
-      showHidden =
-          Provider.of<CategoryProvider>(context, listen: false).showHidden;
+      showHidden = Provider.of<CategoryProvider>(context, listen: false).showHidden;
     });
     for (FileSystemEntity file in l) {
       if (!showHidden) {
@@ -67,14 +64,7 @@ class _FileViewerPageState extends State<FileViewerPage>
       }
     }
 
-    files = FileUtils.sortList(
-        files, Provider.of<CategoryProvider>(context, listen: false).sort);
-//    files.sort((f1, f2) => pathlib.basename(f1.path).toLowerCase().compareTo(pathlib.basename(f2.path).toLowerCase()));
-//    files.sort((f1, f2) => f1.toString().split(":")[0].toLowerCase().compareTo(f2.toString().split(":")[0].toLowerCase()));
-//    files.sort((f1, f2) => FileSystemEntity.isDirectorySync(f1.path) ==
-//        FileSystemEntity.isDirectorySync(f2.path)
-//        ? 0
-//        : 1);
+    files = FileUtils.sortList(files, Provider.of<CategoryProvider>(context, listen: false).sort);
   }
 
   @override
@@ -93,227 +83,209 @@ class _FileViewerPageState extends State<FileViewerPage>
   }
 
   @override
-  Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        if (paths.length == 1) {
-          return true;
-        } else {
-          paths.removeLast();
-          setState(() {
-            path = paths.last;
-          });
-          getFiles();
-          return false;
-        }
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          leading: IconButton(
-            icon: Icon(
-              Icons.arrow_back,
+  Widget build(BuildContext context) => WillPopScope(
+        onWillPop: () async {
+          if (paths.length == 1) {
+            return true;
+          } else {
+            paths.removeLast();
+            setState(() {
+              path = paths.last;
+            });
+            getFiles();
+            return false;
+          }
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            leading: IconButton(
+              icon: Icon(
+                Icons.arrow_back,
+              ),
+              onPressed: () {
+                if (paths.length == 1) {
+                  Navigator.pop(context);
+                } else {
+                  paths.removeLast();
+                  setState(() {
+                    path = paths.last;
+                  });
+                  getFiles();
+                }
+              },
             ),
-            onPressed: () {
-              if (paths.length == 1) {
-                Navigator.pop(context);
-              } else {
-                paths.removeLast();
-                setState(() {
-                  path = paths.last;
-                });
-                getFiles();
-              }
-            },
-          ),
-          elevation: 4,
-          title: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                "${widget.title}",
-              ),
-              Text(
-                "$path",
-                style: TextStyle(
-                  fontSize: 12,
+            elevation: 4,
+            title: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  "${widget.title}",
                 ),
-              ),
-            ],
-          ),
-          bottom: PathBar(
-            child: Container(
-              height: 50,
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: ListView.separated(
-                  scrollDirection: Axis.horizontal,
-                  shrinkWrap: true,
-                  itemCount: paths.length,
-                  itemBuilder: (BuildContext context, int index) {
-                    String i = paths[index];
-                    List splited = i.split("/");
-                    return index == 0
-                        ? IconButton(
-                            icon: Icon(
-                              widget.path.toString().contains("emulated")
-                                  ? Feather.smartphone
-                                  : Icons.sd_card,
-                              color: index == paths.length - 1
-                                  ? Theme.of(context).accentColor
-                                  : Theme.of(context).textTheme.headline6.color,
-                            ),
-                            onPressed: () {
-                              print(paths[index]);
-                              setState(() {
-                                path = paths[index];
-                                paths.removeRange(index + 1, paths.length);
-                              });
-                              getFiles();
-                            },
-                          )
-                        : InkWell(
-                            onTap: () {
-                              print(paths[index]);
-                              setState(() {
-                                path = paths[index];
-                                paths.removeRange(index + 1, paths.length);
-                              });
-                              getFiles();
-                            },
-                            child: Container(
-                              height: 40,
-                              child: Center(
-                                child: Padding(
-                                  padding: EdgeInsets.symmetric(horizontal: 5),
-                                  child: Text(
-                                    "${splited[splited.length - 1]}",
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.bold,
-                                      color: index == paths.length - 1
-                                          ? Theme.of(context).accentColor
-                                          : Theme.of(context)
-                                              .textTheme
-                                              .headline6
-                                              .color,
+              ],
+            ),
+            bottom: PathBar(
+              child: Container(
+                height: 50,
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    shrinkWrap: true,
+                    itemCount: paths.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      final i = paths[index];
+                      final split = i.split("/");
+                      return index == 0
+                          ? IconButton(
+                              icon: Icon(
+                                widget.path.toString().contains("emulated") ? Feather.smartphone : Icons.sd_card,
+                                color: index == paths.length - 1
+                                    ? Theme.of(context).accentColor
+                                    : Theme.of(context).textTheme.headline6.color,
+                              ),
+                              onPressed: () {
+                                print(paths[index]);
+                                setState(() {
+                                  path = paths[index];
+                                  paths.removeRange(index + 1, paths.length);
+                                });
+                                getFiles();
+                              },
+                            )
+                          : InkWell(
+                              onTap: () {
+                                print(paths[index]);
+                                setState(() {
+                                  path = paths[index];
+                                  paths.removeRange(index + 1, paths.length);
+                                });
+                                getFiles();
+                              },
+                              child: Container(
+                                height: 40,
+                                child: Center(
+                                  child: Padding(
+                                    padding: EdgeInsets.symmetric(horizontal: 5),
+                                    child: Text(
+                                      "${split[split.length - 1]}",
+                                      style: TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                        color: index == paths.length - 1
+                                            ? Theme.of(context).accentColor
+                                            : Theme.of(context).textTheme.headline6.color,
+                                      ),
                                     ),
                                   ),
                                 ),
                               ),
-                            ),
-                          );
-                  },
-                  separatorBuilder: (BuildContext context, int index) {
-                    return Icon(
-                      Icons.arrow_forward_ios,
-                    );
-                  },
+                            );
+                    },
+                    separatorBuilder: (BuildContext context, int index) {
+                      return Icon(
+                        Icons.arrow_forward_ios,
+                      );
+                    },
+                  ),
                 ),
               ),
             ),
+            actions: <Widget>[
+              IconButton(
+                onPressed: () {
+                  showModalBottomSheet(
+                    context: context,
+                    builder: (context) => SortSheet(),
+                  ).then((v) {
+                    getFiles();
+                  });
+                },
+                tooltip: R.current.sortBy,
+                icon: Icon(
+                  Icons.sort,
+                ),
+              ),
+            ],
           ),
-          actions: <Widget>[
-            IconButton(
-              onPressed: () {
-                showModalBottomSheet(
-                  context: context,
-                  builder: (context) => SortSheet(),
-                ).then((v) {
-                  getFiles();
-                });
-              },
-              tooltip: R.current.sortBy,
-              icon: Icon(
-                Icons.sort,
-              ),
-            ),
-          ],
-        ),
-        body: files.isEmpty
-            ? Center(
-                child: Text(R.current.nothingHere),
-              )
-            : ListView.separated(
-                padding: EdgeInsets.only(left: 20),
-                itemCount: files.length,
-                itemBuilder: (BuildContext context, int index) {
-                  FileSystemEntity file = files[index];
-                  return file.toString().split(":")[0] == "Directory"
-                      ? DirectoryItem(
-                          popTap: (v) async {
-                            if (v == 0) {
-                              renameDialog(context, file.path, "dir");
-                            } else if (v == 1) {
-                              await Directory(file.path)
-                                  .delete(recursive: true) //將會刪除資料夾內所有東西
-                                  .catchError((e) {
-                                print(e.toString());
-                                if (e
-                                    .toString()
-                                    .contains("Permission denied")) {
-                                  MyToast.show(R.current.cannotWrite);
-                                }
+          body: files.isEmpty
+              ? Center(
+                  child: Text(R.current.nothingHere),
+                )
+              : ListView.separated(
+                  padding: EdgeInsets.only(left: 20),
+                  itemCount: files.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    final file = files[index];
+                    return file.toString().split(":")[0] == "Directory"
+                        ? DirectoryItem(
+                            popTap: (v) async {
+                              if (v == 0) {
+                                renameDialog(context, file.path, "dir");
+                              } else if (v == 1) {
+                                await Directory(file.path).delete(recursive: true) //將會刪除資料夾內所有東西
+                                    .catchError((e) {
+                                  print(e.toString());
+                                  if (e.toString().contains("Permission denied")) {
+                                    MyToast.show(R.current.cannotWrite);
+                                  }
+                                });
+                                getFiles();
+                              }
+                            },
+                            file: file,
+                            tap: () {
+                              paths.add(file.path);
+                              setState(() {
+                                path = file.path;
                               });
                               getFiles();
-                            }
-                          },
-                          file: file,
-                          tap: () {
-                            paths.add(file.path);
-                            setState(() {
-                              path = file.path;
-                            });
-                            getFiles();
-                          },
-                        )
-                      : FileItem(
-                          file: file,
-                          popTap: (v) async {
-                            if (v == 0) {
-                              renameDialog(context, file.path, "file");
-                            } else if (v == 1) {
-                              await File(file.path).delete().catchError((e) {
-                                print(e.toString());
-                                if (e
-                                    .toString()
-                                    .contains("Permission denied")) {
-                                  MyToast.show(R.current.cannotWrite);
-                                }
-                              });
-                              getFiles();
-                            } else if (v == 2) {
-                              print("Share");
-                            }
-                          },
-                        );
-                },
-                separatorBuilder: (BuildContext context, int index) {
-                  return Stack(
-                    children: <Widget>[
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Container(
-                          height: 1,
-                          color: Theme.of(context).dividerColor,
-                          width: MediaQuery.of(context).size.width - 70,
+                            },
+                          )
+                        : FileItem(
+                            file: file,
+                            popTap: (v) async {
+                              if (v == 0) {
+                                renameDialog(context, file.path, "file");
+                              } else if (v == 1) {
+                                await File(file.path).delete().catchError((e) {
+                                  print(e.toString());
+                                  if (e.toString().contains("Permission denied")) {
+                                    MyToast.show(R.current.cannotWrite);
+                                  }
+                                });
+                                getFiles();
+                              } else if (v == 2) {
+                                print("Share");
+                              }
+                            },
+                          );
+                  },
+                  separatorBuilder: (BuildContext context, int index) {
+                    return Stack(
+                      children: <Widget>[
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: Container(
+                            height: 1,
+                            color: Theme.of(context).dividerColor,
+                            width: MediaQuery.of(context).size.width - 70,
+                          ),
                         ),
-                      ),
-                    ],
-                  );
-                },
-              ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () => addDialog(context, path),
-          child: Icon(Feather.plus),
-          tooltip: "Add Folder",
+                      ],
+                    );
+                  },
+                ),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () => addDialog(context, path),
+            child: Icon(Feather.plus),
+            tooltip: "Add Folder",
+          ),
         ),
-      ),
-    );
-  }
+      );
 
   addDialog(BuildContext context, String path) {
-    final TextEditingController name = TextEditingController();
+    final name = TextEditingController();
     Get.dialog(
       CustomAlert(
         child: Padding(
@@ -347,8 +319,7 @@ class _FileViewerPageState extends State<FileViewerPage>
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(5.0),
                       ),
-                      borderSide:
-                          BorderSide(color: Theme.of(context).accentColor),
+                      borderSide: BorderSide(color: Theme.of(context).accentColor),
                       child: Text(
                         R.current.cancel,
                         style: TextStyle(
@@ -375,9 +346,7 @@ class _FileViewerPageState extends State<FileViewerPage>
                       onPressed: () async {
                         if (name.text.isNotEmpty) {
                           if (!Directory(path + "/${name.text}").existsSync()) {
-                            await Directory(path + "/${name.text}")
-                                .create()
-                                .catchError((e) {
+                            await Directory(path + "/${name.text}").create().catchError((e) {
                               print(e.toString());
                               if (e.toString().contains("Permission denied")) {
                                 MyToast.show(R.current.cannotWrite);
@@ -406,7 +375,7 @@ class _FileViewerPageState extends State<FileViewerPage>
   }
 
   renameDialog(BuildContext context, String path, String type) {
-    final TextEditingController name = TextEditingController();
+    final name = TextEditingController();
     setState(() {
       name.text = pathLib.basename(path);
     });
@@ -443,8 +412,7 @@ class _FileViewerPageState extends State<FileViewerPage>
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(5.0),
                       ),
-                      borderSide:
-                          BorderSide(color: Theme.of(context).accentColor),
+                      borderSide: BorderSide(color: Theme.of(context).accentColor),
                       child: Text(
                         R.current.cancel,
                         style: TextStyle(
@@ -471,19 +439,12 @@ class _FileViewerPageState extends State<FileViewerPage>
                       onPressed: () async {
                         if (name.text.isNotEmpty) {
                           if (type == "file") {
-                            if (!File(path.replaceAll(
-                                        pathLib.basename(path), "") +
-                                    "${name.text}")
-                                .existsSync()) {
+                            if (!File(path.replaceAll(pathLib.basename(path), "") + "${name.text}").existsSync()) {
                               await File(path)
-                                  .rename(path.replaceAll(
-                                          pathLib.basename(path), "") +
-                                      "${name.text}")
+                                  .rename(path.replaceAll(pathLib.basename(path), "") + "${name.text}")
                                   .catchError((e) {
                                 print(e.toString());
-                                if (e
-                                    .toString()
-                                    .contains("Permission denied")) {
+                                if (e.toString().contains("Permission denied")) {
                                   MyToast.show(R.current.cannotWrite);
                                 }
                               });
@@ -491,21 +452,14 @@ class _FileViewerPageState extends State<FileViewerPage>
                               MyToast.show(R.current.fileNameAlreadyExists);
                             }
                           } else {
-                            if (Directory(path.replaceAll(
-                                        pathLib.basename(path), "") +
-                                    "${name.text}")
-                                .existsSync()) {
+                            if (Directory(path.replaceAll(pathLib.basename(path), "") + "${name.text}").existsSync()) {
                               MyToast.show(R.current.fileNameAlreadyExists);
                             } else {
                               await Directory(path)
-                                  .rename(path.replaceAll(
-                                          pathLib.basename(path), "") +
-                                      "${name.text}")
+                                  .rename(path.replaceAll(pathLib.basename(path), "") + "${name.text}")
                                   .catchError((e) {
                                 print(e.toString());
-                                if (e
-                                    .toString()
-                                    .contains("Permission denied")) {
+                                if (e.toString().contains("Permission denied")) {
                                   MyToast.show(R.current.cannotWrite);
                                 }
                               });

--- a/lib/ui/pages/fileviewer/widgets/custom_alert.dart
+++ b/lib/ui/pages/fileviewer/widgets/custom_alert.dart
@@ -2,33 +2,20 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
-// ignore: must_be_immutable
 class CustomAlert extends StatelessWidget {
   final Widget child;
 
-  CustomAlert({Key key, @required this.child}) : super(key: key);
-
-  double deviceWidth;
-  double deviceHeight;
-  double dialogHeight;
+  const CustomAlert({Key key, @required this.child}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    Orientation orientation = MediaQuery.of(context).orientation;
-    Size screenSize = MediaQuery.of(context).size;
-
-    deviceWidth = orientation == Orientation.portrait
-        ? screenSize.width
-        : screenSize.height;
-    deviceHeight = orientation == Orientation.portrait
-        ? screenSize.height
-        : screenSize.width;
-    dialogHeight = deviceHeight * (0.50);
+    final orientation = MediaQuery.of(context).orientation;
+    final screenSize = MediaQuery.of(context).size;
+    final deviceWidth = orientation == Orientation.portrait ? screenSize.width : screenSize.height;
 
     return MediaQuery(
       data: MediaQueryData(),
       child: GestureDetector(
-//        onTap: ()=>Navigator.pop(context),
         child: BackdropFilter(
           filter: ImageFilter.blur(
             sigmaX: 0.5,

--- a/lib/ui/pages/fileviewer/widgets/dir_item.dart
+++ b/lib/ui/pages/fileviewer/widgets/dir_item.dart
@@ -11,7 +11,7 @@ class DirectoryItem extends StatelessWidget {
   final Function tap;
   final Function popTap;
 
-  DirectoryItem({
+  const DirectoryItem({
     Key key,
     @required this.file,
     @required this.tap,
@@ -19,28 +19,25 @@ class DirectoryItem extends StatelessWidget {
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      onTap: tap,
-      contentPadding: EdgeInsets.all(0),
-      leading: Container(
-        height: 40,
-        width: 40,
-        child: Center(
-          child: Icon(
-            Feather.folder,
+  Widget build(BuildContext context) => ListTile(
+        onTap: tap,
+        contentPadding: EdgeInsets.all(0),
+        leading: Container(
+          height: 40,
+          width: 40,
+          child: Center(
+            child: Icon(
+              Feather.folder,
+            ),
           ),
         ),
-      ),
-      title: Text(
-        "${basename(file.path)}",
-        style: TextStyle(
-          fontSize: 14,
+        title: Text(
+          "${basename(file.path)}",
+          style: TextStyle(
+            fontSize: 14,
+          ),
+          maxLines: 2,
         ),
-        maxLines: 2,
-      ),
-      trailing:
-          popTap == null ? null : DirPopup(path: file.path, popTap: popTap),
-    );
-  }
+        trailing: popTap == null ? null : DirPopup(path: file.path, popTap: popTap),
+      );
 }

--- a/lib/ui/pages/fileviewer/widgets/dir_popup.dart
+++ b/lib/ui/pages/fileviewer/widgets/dir_popup.dart
@@ -5,36 +5,34 @@ class DirPopup extends StatelessWidget {
   final String path;
   final Function popTap;
 
-  DirPopup({
+  const DirPopup({
     Key key,
     @required this.path,
     @required this.popTap,
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<int>(
-      onSelected: popTap,
-      itemBuilder: (context) => [
-        PopupMenuItem(
-          value: 0,
-          child: Text(
-            R.current.rename,
+  Widget build(BuildContext context) => PopupMenuButton<int>(
+        onSelected: popTap,
+        itemBuilder: (context) => [
+          PopupMenuItem(
+            value: 0,
+            child: Text(
+              R.current.rename,
+            ),
           ),
-        ),
-        PopupMenuItem(
-          value: 1,
-          child: Text(
-            R.current.delete,
+          PopupMenuItem(
+            value: 1,
+            child: Text(
+              R.current.delete,
+            ),
           ),
+        ],
+        icon: Icon(
+          Icons.arrow_drop_down,
+          color: Theme.of(context).textTheme.headline6.color,
         ),
-      ],
-      icon: Icon(
-        Icons.arrow_drop_down,
-        color: Theme.of(context).textTheme.headline6.color,
-      ),
-      color: Theme.of(context).scaffoldBackgroundColor,
-      offset: Offset(0, 30),
-    );
-  }
+        color: Theme.of(context).scaffoldBackgroundColor,
+        offset: Offset(0, 30),
+      );
 }

--- a/lib/ui/pages/fileviewer/widgets/file_icon.dart
+++ b/lib/ui/pages/fileviewer/widgets/file_icon.dart
@@ -8,17 +8,17 @@ import 'package:path/path.dart';
 class FileIcon extends StatelessWidget {
   final FileSystemEntity file;
 
-  FileIcon({
+  const FileIcon({
     Key key,
     @required this.file,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    File f = File(file.path);
-    String _extension = extension(f.path).toLowerCase();
-    String mimeType = mime(basename(file.path).toLowerCase());
-    String type = mimeType == null ? "" : mimeType.split("/")[0];
+    final f = File(file.path);
+    final _extension = extension(f.path).toLowerCase();
+    final mimeType = mime(basename(file.path).toLowerCase());
+    final type = mimeType == null ? "" : mimeType.split("/")[0];
     if (_extension == ".apk") {
       return Icon(
         Icons.android,
@@ -33,9 +33,7 @@ class FileIcon extends StatelessWidget {
       return Icon(
         Feather.archive,
       );
-    } else if (_extension == ".epub" ||
-        _extension == ".pdf" ||
-        _extension == ".mobi") {
+    } else if (_extension == ".epub" || _extension == ".pdf" || _extension == ".mobi") {
       return Icon(
         Feather.file_text,
         color: Colors.orangeAccent,
@@ -51,25 +49,6 @@ class FileIcon extends StatelessWidget {
             );
           }
           break;
-/*
-        case "video":
-          {
-//            return Image.file(
-//              File(),
-//              height: 40,
-//              width: 40,
-//            );
-            return Container(
-              height: 40,
-              width: 40,
-              child: VideoThumbnail(
-                path: file.path,
-              ),
-            );
-          }
-          break;
- */
-
         case "audio":
           {
             return Icon(

--- a/lib/ui/pages/fileviewer/widgets/file_item.dart
+++ b/lib/ui/pages/fileviewer/widgets/file_item.dart
@@ -12,37 +12,35 @@ class FileItem extends StatelessWidget {
   final FileSystemEntity file;
   final Function popTap;
 
-  FileItem({
+  const FileItem({
     Key key,
     @required this.file,
     this.popTap,
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      onTap: () => OpenFile.open(file.path),
-      contentPadding: EdgeInsets.all(0),
-      leading: FileIcon(
-        file: file,
-      ),
-      title: Text(
-        "${basename(file.path)}",
-        style: TextStyle(
-          fontSize: 14,
+  Widget build(BuildContext context) => ListTile(
+        onTap: () => OpenFile.open(file.path),
+        contentPadding: EdgeInsets.all(0),
+        leading: FileIcon(
+          file: file,
         ),
-        maxLines: 2,
-      ),
-      subtitle: Text(
-        "${FileUtils.formatBytes(file == null ? 678476 : File(file.path).lengthSync(), 2)},"
-        " ${file == null ? "Test" : FileUtils.formatTime(File(file.path).lastModifiedSync().toIso8601String())}",
-      ),
-      trailing: popTap == null
-          ? null
-          : FilePopup(
-              path: file.path,
-              popTap: popTap,
-            ),
-    );
-  }
+        title: Text(
+          "${basename(file.path)}",
+          style: TextStyle(
+            fontSize: 14,
+          ),
+          maxLines: 2,
+        ),
+        subtitle: Text(
+          "${FileUtils.formatBytes(file == null ? 678476 : File(file.path).lengthSync(), 2)},"
+          " ${file == null ? "Test" : FileUtils.formatTime(File(file.path).lastModifiedSync().toIso8601String())}",
+        ),
+        trailing: popTap == null
+            ? null
+            : FilePopup(
+                path: file.path,
+                popTap: popTap,
+              ),
+      );
 }

--- a/lib/ui/pages/fileviewer/widgets/file_popup.dart
+++ b/lib/ui/pages/fileviewer/widgets/file_popup.dart
@@ -5,42 +5,34 @@ class FilePopup extends StatelessWidget {
   final String path;
   final Function popTap;
 
-  FilePopup({
+  const FilePopup({
     Key key,
     @required this.path,
     @required this.popTap,
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<int>(
-      onSelected: popTap,
-      itemBuilder: (context) => [
-        PopupMenuItem(
-          value: 0,
-          child: Text(
-            R.current.rename,
+  Widget build(BuildContext context) => PopupMenuButton<int>(
+        onSelected: popTap,
+        itemBuilder: (context) => [
+          PopupMenuItem(
+            value: 0,
+            child: Text(
+              R.current.rename,
+            ),
           ),
-        ),
-        PopupMenuItem(
-          value: 1,
-          child: Text(
-            R.current.delete,
+          PopupMenuItem(
+            value: 1,
+            child: Text(
+              R.current.delete,
+            ),
           ),
+        ],
+        icon: Icon(
+          Icons.arrow_drop_down,
+          color: Theme.of(context).textTheme.headline6.color,
         ),
-//        PopupMenuItem(
-//          value: 2,
-//          child: Text(
-//            "Info",
-//          ),
-//        ),
-      ],
-      icon: Icon(
-        Icons.arrow_drop_down,
-        color: Theme.of(context).textTheme.headline6.color,
-      ),
-      color: Theme.of(context).scaffoldBackgroundColor,
-      offset: Offset(0, 30),
-    );
-  }
+        color: Theme.of(context).scaffoldBackgroundColor,
+        offset: Offset(0, 30),
+      );
 }

--- a/lib/ui/pages/fileviewer/widgets/path_bar.dart
+++ b/lib/ui/pages/fileviewer/widgets/path_bar.dart
@@ -3,15 +3,13 @@ import 'package:flutter/material.dart';
 class PathBar extends StatelessWidget implements PreferredSizeWidget {
   final Widget child;
 
-  PathBar({
+  const PathBar({
     Key key,
     @required this.child,
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return child;
-  }
+  Widget build(BuildContext context) => child;
 
   @override
   Size get preferredSize => Size.fromHeight(40.0);

--- a/lib/ui/pages/fileviewer/widgets/sort_sheet.dart
+++ b/lib/ui/pages/fileviewer/widgets/sort_sheet.dart
@@ -7,67 +7,57 @@ import 'package:provider/provider.dart';
 
 class SortSheet extends StatelessWidget {
   @override
-  Widget build(BuildContext context) {
-    return FractionallySizedBox(
-      heightFactor: 0.85,
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            SizedBox(
-              height: 15,
-            ),
-            Text(
-              R.current.sortBy,
-              style: TextStyle(
-                fontSize: 12.0,
+  Widget build(BuildContext context) => FractionallySizedBox(
+        heightFactor: 0.85,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              SizedBox(
+                height: 15,
               ),
-            ),
-            SizedBox(
-              height: 10,
-            ),
-            Flexible(
-              child: ListView.builder(
-                itemCount: Constants.sortList.length,
-                itemBuilder: (BuildContext context, int index) {
-                  return ListTile(
-                    onTap: () async {
-                      await Provider.of<CategoryProvider>(context,
-                              listen: false)
-                          .setSort(index);
-                      Navigator.pop(context);
-                    },
-                    contentPadding: EdgeInsets.all(0),
-                    trailing: index ==
-                            Provider.of<CategoryProvider>(context,
-                                    listen: false)
-                                .sort
-                        ? Icon(
-                            Feather.check,
-                            color: Colors.blue,
-                            size: 16,
-                          )
-                        : SizedBox(),
-                    title: Text(
-                      "${Constants.sortList[index]}",
-                      style: TextStyle(
-                        fontSize: 14.0,
-                        color: index ==
-                                Provider.of<CategoryProvider>(context,
-                                        listen: false)
-                                    .sort
-                            ? Colors.blue
-                            : Theme.of(context).textTheme.headline6.color,
+              Text(
+                R.current.sortBy,
+                style: TextStyle(
+                  fontSize: 12.0,
+                ),
+              ),
+              SizedBox(
+                height: 10,
+              ),
+              Flexible(
+                child: ListView.builder(
+                  itemCount: Constants.sortList.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    return ListTile(
+                      onTap: () async {
+                        await Provider.of<CategoryProvider>(context, listen: false).setSort(index);
+                        Navigator.pop(context);
+                      },
+                      contentPadding: EdgeInsets.all(0),
+                      trailing: index == Provider.of<CategoryProvider>(context, listen: false).sort
+                          ? Icon(
+                              Feather.check,
+                              color: Colors.blue,
+                              size: 16,
+                            )
+                          : SizedBox(),
+                      title: Text(
+                        "${Constants.sortList[index]}",
+                        style: TextStyle(
+                          fontSize: 14.0,
+                          color: index == Provider.of<CategoryProvider>(context, listen: false).sort
+                              ? Colors.blue
+                              : Theme.of(context).textTheme.headline6.color,
+                        ),
                       ),
-                    ),
-                  );
-                },
+                    );
+                  },
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
-    );
-  }
+      );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -923,7 +923,7 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1+1"
+    version: "5.1.0+2"
   permission_handler_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   path: ^1.7.0
   provider: ^4.3.3
-  path_provider: ^1.6.27
+  path_provider: ^1.6.28
   url_launcher: 5.5.0
   #開啟email phone url...
   logger: ^0.9.4
@@ -85,7 +85,7 @@ dependencies:
   flutter_downloader: ^1.5.2
   #下載app更新
   open_file: ^3.0.3
-  permission_handler: 5.0.1+1
+  permission_handler: ^5.1.0+2
   mime_type: 0.3.2
   #----------Widget----------#
   get: ^3.24.0


### PR DESCRIPTION
## Description
- The permission check process for android external storage (id = 15) is wrong and redundant.
In this PR, I just rewrite it again, and it seems works fine on API level 31.

- Issue fixed:
https://stackoverflow.com/questions/51607002/flutter-unable-to-create-directory-os-error-read-only-file-system

- The root file download path has been move to ./TAT now.

- remove path text on the appBar of file page.