### PR TITLE
Fix: getx route change warning

### DIFF
--- a/lib/src/task/ntut/NTUTTask.dart
+++ b/lib/src/task/ntut/NTUTTask.dart
@@ -54,7 +54,7 @@ class NTUTTask<T> extends DialogTask<T> {
         parameter.desc = R.current.accountPasswordError;
         parameter.btnOkText = R.current.setting;
         parameter.btnOkOnPress = () {
-          Get.to(LoginScreen()).then((value) => Get.back<bool>(result: true));
+          Get.to(() => LoginScreen()).then((value) => Get.back<bool>(result: true));
         };
         break;
       case NTUTConnectorStatus.AuthCodeFailError:

--- a/lib/src/task/ntut/NTUTTask.dart
+++ b/lib/src/task/ntut/NTUTTask.dart
@@ -34,10 +34,8 @@ class NTUTTask<T> extends DialogTask<T> {
     NTUTAppTask.isLogin = false;
     if (value == NTUTConnectorStatus.LoginSuccess) {
       _isLogin = true;
-      print('#########################');
       return TaskStatus.Success;
     } else {
-      print('@@@@@@@@@@@@@@@@@@@@@@@@@@');
       return await _onError(value);
     }
   }

--- a/lib/ui/other/RouteUtils.dart
+++ b/lib/ui/other/RouteUtils.dart
@@ -20,29 +20,28 @@ import 'package:flutter_app/ui/screen/LoginScreen.dart';
 import 'package:get/get.dart';
 
 class RouteUtils {
-  static Transition transition =
-      (Platform.isAndroid) ? Transition.downToUp : Transition.cupertino;
+  static Transition transition = (Platform.isAndroid) ? Transition.downToUp : Transition.cupertino;
 
   static Future toLoginScreen() async {
     return await Get.to(
-      LoginScreen(),
+      () => LoginScreen(),
       transition: transition,
     );
   }
 
   static Future toDevPage() async {
     return await Get.to(
-      DevPage(),
+      () => DevPage(),
       transition: transition,
     );
   }
 
   static Future toSubSystemPage(String title, String arg) async {
     return Get.to(
-        SubSystemPage(
-          title: title,
-          arg: arg,
-        ),
+        () => SubSystemPage(
+              title: title,
+              arg: arg,
+            ),
         transition: transition,
         preventDuplicates: false //必免重覆頁面時不載入
         );
@@ -50,52 +49,51 @@ class RouteUtils {
 
   static Future toFileViewerPage(String title, String path) async {
     return await Get.to(
-        FileViewerPage(
-          title: title,
-          path: path,
-        ),
+        () => FileViewerPage(
+              title: title,
+              path: path,
+            ),
         transition: transition);
   }
 
-  static Future toISchoolPage(
-      String studentId, CourseInfoJson courseInfo) async {
+  static Future toISchoolPage(String studentId, CourseInfoJson courseInfo) async {
     return await Get.to(
-      ISchoolPage(studentId, courseInfo),
+      () => ISchoolPage(studentId, courseInfo),
       transition: transition,
     );
   }
 
   static Future toPrivacyPolicyPage() async {
     return await Get.to(
-      PrivacyPolicyPage(),
+      () => PrivacyPolicyPage(),
       transition: transition,
     );
   }
 
   static Future toContributorsPage() async {
     return await Get.to(
-      ContributorsPage(),
+      () => ContributorsPage(),
       transition: transition,
     );
   }
 
   static Future toAboutPage() async {
     return await Get.to(
-      AboutPage(),
+      () => AboutPage(),
       transition: transition,
     );
   }
 
   static Future toSettingPage(PageController controller) async {
     return await Get.to(
-      SettingPage(controller),
+      () => SettingPage(controller),
       transition: transition,
     );
   }
 
   static Future toWebViewPluginPage(String title, String url) async {
     return await Get.to(
-      WebViewPluginPage(
+      () => WebViewPluginPage(
         title: title,
         url: url,
       ),
@@ -105,7 +103,7 @@ class RouteUtils {
 
   static Future toWebViewPage(String title, String url) async {
     return await Get.to(
-      WebViewPage(
+      () => WebViewPage(
         title: title,
         url: url,
       ),
@@ -115,7 +113,7 @@ class RouteUtils {
 
   static Future toLogConsolePage() async {
     return await Get.to(
-      LogConsole(dark: true),
+      () => LogConsole(dark: true),
       transition: transition,
     );
   }
@@ -124,18 +122,16 @@ class RouteUtils {
     DioConnector.instance.alice.showInspector();
   }
 
-  static Future toIPlusAnnouncementDetailPage(
-      CourseInfoJson courseInfo, Map detail) async {
+  static Future toIPlusAnnouncementDetailPage(CourseInfoJson courseInfo, Map detail) async {
     return await Get.to(
-      IPlusAnnouncementDetailPage(courseInfo, detail),
+      () => IPlusAnnouncementDetailPage(courseInfo, detail),
       transition: transition,
     );
   }
 
-  static Future toVideoPlayer(
-      String url, CourseInfoJson courseInfo, String name) async {
+  static Future toVideoPlayer(String url, CourseInfoJson courseInfo, String name) async {
     return await Get.to(
-      ClassVideoPlayer(url, courseInfo, name),
+      () => ClassVideoPlayer(url, courseInfo, name),
       transition: transition,
     );
   }


### PR DESCRIPTION
## Description
In the new `GetX` package, it has a new API when using `Get.to(...)`:

```dart
    Get.to(
      () => ExamplePage(),
      transition: transition,
    );
```

instead of

```dart
    Get.to(
      ExamplePage(),
      transition: transition,
    );
```