### PR TITLE
Fix: dio istudy header parse error

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -61,22 +61,22 @@ PODS:
   - Firebase/RemoteConfig (8.14.0):
     - Firebase/CoreOnly
     - FirebaseRemoteConfig (~> 8.14.0)
-  - firebase_analytics (9.1.4):
+  - firebase_analytics (9.1.5):
     - Firebase/Analytics (= 8.14.0)
     - firebase_core
     - Flutter
-  - firebase_core (1.14.0):
+  - firebase_core (1.14.1):
     - Firebase/CoreOnly (= 8.14.0)
     - Flutter
-  - firebase_crashlytics (2.6.1):
+  - firebase_crashlytics (2.6.2):
     - Firebase/Crashlytics (= 8.14.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (11.2.12):
+  - firebase_messaging (11.2.13):
     - Firebase/Messaging (= 8.14.0)
     - firebase_core
     - Flutter
-  - firebase_remote_config (2.0.3):
+  - firebase_remote_config (2.0.4):
     - Firebase/RemoteConfig (= 8.14.0)
     - firebase_core
     - Flutter
@@ -213,7 +213,7 @@ PODS:
   - HLSCachingReverseProxyServer (0.1.0):
     - GCDWebServer (~> 3.5)
     - PINCache (>= 3.0.1-beta.3)
-  - local_auth (0.0.1):
+  - local_auth_ios (0.0.1):
     - Flutter
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
@@ -279,7 +279,7 @@ DEPENDENCIES:
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_webview_plugin (from `.symlinks/plugins/flutter_webview_plugin/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
-  - local_auth (from `.symlinks/plugins/local_auth/ios`)
+  - local_auth_ios (from `.symlinks/plugins/local_auth_ios/ios`)
   - open_file (from `.symlinks/plugins/open_file/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -356,8 +356,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_webview_plugin/ios"
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
-  local_auth:
-    :path: ".symlinks/plugins/local_auth/ios"
+  local_auth_ios:
+    :path: ".symlinks/plugins/local_auth_ios/ios"
   open_file:
     :path: ".symlinks/plugins/open_file/ios"
   package_info:
@@ -397,11 +397,11 @@ SPEC CHECKSUMS:
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
   file_picker: 3e6c3790de664ccf9b882732d9db5eaf6b8d4eb1
   Firebase: 7e8fe528c161b9271d365217a74c16aaf834578e
-  firebase_analytics: 3d3cbbe452befde99014d7f6fd281bbb4e6f96da
-  firebase_core: b0b382f1497ab407aceb25e41e3036c8798c1609
-  firebase_crashlytics: 4855a96241cfc4cb92a81bebedc29ea29488373a
-  firebase_messaging: 34dd10d1aa6d8f40d03660eeacd0452d62eec7aa
-  firebase_remote_config: 892caabe89e466aa8d503692920cb79ccf2afbc3
+  firebase_analytics: 8a36c76380be1fca3bab69534cf911082e0d7ab8
+  firebase_core: cdef02fcf55872191eb0568d4c31a7a700e38582
+  firebase_crashlytics: 6c0450e99d20c62d0cd868f287a12aeffbe9b010
+  firebase_messaging: 57f89047ec0084a4049e253ce84cea39becadad4
+  firebase_remote_config: c038c6badd049a19f6f6be77b253a7680ece5fa9
   FirebaseABTesting: aaa0e096c9fc9972ce6806d596e8fcc077d4371f
   FirebaseAnalytics: 2fc3876e2eb347673ad2f35e249ae7b15d6c88f5
   FirebaseCore: b84a44ee7ba999e0f9f76d198a9c7f60a797b848
@@ -423,7 +423,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   HLSCachingReverseProxyServer: 59935e1e0244ad7f3375d75b5ef46e8eb26ab181
-  local_auth: 1740f55d7af0a2e2a8684ce225fe79d8931e808c
+  local_auth_ios: 0d333dde7780f669e66f19d2ff6005f3ea84008d
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   open_file: 02eb5cb6b21264bd3a696876f5afbfb7ca4f4b7d
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c

--- a/lib/src/connector/adapters/early_interceptor_adapter.dart
+++ b/lib/src/connector/adapters/early_interceptor_adapter.dart
@@ -1,0 +1,183 @@
+// 🎯 Dart imports:
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+// 📦 Package imports:
+import 'package:dio/dio.dart';
+import 'package:meta/meta.dart';
+
+// 🌎 Project imports:
+import 'package:tat_core/src/utils/debug_util.dart';
+
+/// An adapter which lets you do something before the Dio interceptor executes.
+///
+/// Inherited from the `DefaultHttpClientAdapter` of Dio v4.0.6,
+/// please refer to https://pub.dev/packages/dio for more details.
+@immutable
+@protected
+@sealed
+class EarlyInterceptorAdapter implements HttpClientAdapter {
+  late final HttpClient? _defaultHttpClient;
+  final Completer _adapterLife = Completer();
+
+  @override
+  void close({bool force = false}) {
+    _adapterLife.complete();
+    _defaultHttpClient?.close(force: force);
+  }
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future? cancelFuture,
+  ) async {
+    if (_adapterLife.isCompleted) {
+      const msg = "Can't establish connection after [HttpClientAdapter] closed!";
+      _log(msg, areaName: 'fetch');
+      throw Exception(msg);
+    }
+
+    final _httpClient = _configHttpClient(cancelFuture, options.connectTimeout);
+    final reqFuture = _httpClient.openUrl(options.method, options.uri);
+
+    void _throwConnectingTimeout() => throw DioError(
+          requestOptions: options,
+          error: 'Connecting timed out [${options.connectTimeout}ms]',
+          type: DioErrorType.connectTimeout,
+        );
+
+    late final HttpClientRequest request;
+    try {
+      request = options.connectTimeout > 0
+          ? await reqFuture.timeout(Duration(milliseconds: options.connectTimeout))
+          : await reqFuture;
+
+      options.headers.forEach((k, v) {
+        if (v != null) request.headers.set(k, '$v');
+      });
+    } on SocketException catch (e) {
+      if (e.message.contains('timed out')) {
+        _throwConnectingTimeout();
+      }
+      rethrow;
+    } on TimeoutException {
+      _throwConnectingTimeout();
+    }
+
+    request
+      ..followRedirects = options.followRedirects
+      ..maxRedirects = options.maxRedirects;
+
+    if (requestStream != null) {
+      // Transform the request data
+      var future = request.addStream(requestStream);
+      if (options.sendTimeout > 0) {
+        future = future.timeout(Duration(milliseconds: options.sendTimeout));
+      }
+      try {
+        await future;
+      } on TimeoutException {
+        request.abort();
+        throw DioError(
+          requestOptions: options,
+          error: 'Sending timeout[${options.sendTimeout}ms]',
+          type: DioErrorType.sendTimeout,
+        );
+      }
+    }
+
+    // [receiveTimeout] represents a timeout during data transfer! That is to say the
+    // client has connected to the server.
+    final receiveStart = DateTime.now().millisecondsSinceEpoch;
+
+    var future = request.close();
+    if (options.receiveTimeout > 0) {
+      future = future.timeout(Duration(milliseconds: options.receiveTimeout));
+    }
+
+    late HttpClientResponse responseStream;
+    try {
+      responseStream = await future;
+    } on TimeoutException {
+      throw DioError(
+        requestOptions: options,
+        error: 'Receiving data timeout[${options.receiveTimeout}ms]',
+        type: DioErrorType.receiveTimeout,
+      );
+    }
+
+    final stream = responseStream.transform<Uint8List>(
+      StreamTransformer.fromHandlers(
+        handleData: (data, sink) {
+          if (options.receiveTimeout > 0 &&
+              DateTime.now().millisecondsSinceEpoch - receiveStart > options.receiveTimeout) {
+            sink.addError(
+              DioError(
+                requestOptions: options,
+                error: 'Receiving data timeout[${options.receiveTimeout}ms]',
+                type: DioErrorType.receiveTimeout,
+              ),
+            );
+            responseStream.detachSocket().then((socket) => socket.destroy());
+          } else {
+            sink.add(Uint8List.fromList(data));
+          }
+        },
+      ),
+    );
+
+    final headers = <String, List<String>>{};
+    responseStream.headers.forEach((key, values) {
+      headers[key] = values;
+    });
+
+    return ResponseBody(
+      stream,
+      responseStream.statusCode,
+      headers: headers,
+      isRedirect: responseStream.isRedirect || responseStream.redirects.isNotEmpty,
+      redirects: responseStream.redirects
+          .map(
+            (e) => RedirectRecord(
+              e.statusCode,
+              e.method,
+              e.location,
+            ),
+          )
+          .toList(),
+      statusMessage: responseStream.reasonPhrase,
+    );
+  }
+
+  HttpClient _configHttpClient(Future? cancelFuture, int connectionTimeout) {
+    final _connectionTimeout = connectionTimeout > 0 ? Duration(milliseconds: connectionTimeout) : null;
+
+    if (cancelFuture != null) {
+      final _httpClient = HttpClient()
+        ..userAgent = null
+        ..idleTimeout = Duration.zero;
+
+      cancelFuture.whenComplete(() {
+        Future.delayed(Duration.zero).then((_) {
+          try {
+            _httpClient.close(force: true);
+          } catch (e) {
+            _log(e, areaName: '_configHttpClient');
+          }
+        });
+      });
+      return _httpClient..connectionTimeout = _connectionTimeout;
+    }
+
+    if (_defaultHttpClient == null) {
+      _defaultHttpClient = HttpClient();
+      _defaultHttpClient!.idleTimeout = const Duration(seconds: 3);
+      _defaultHttpClient!.connectionTimeout = _connectionTimeout;
+    }
+    return _defaultHttpClient!;
+  }
+}
+
+final _log = createNamedLog((EarlyInterceptorAdapter).toString());

--- a/lib/src/connector/core/DioConnector.dart
+++ b/lib/src/connector/core/DioConnector.dart
@@ -20,34 +20,34 @@ class DioConnector {
     HttpHeaders.userAgentHeader: presetUserAgent,
     "Upgrade-Insecure-Requests": "1",
   };
-  Alice alice = Alice(
+
+  final alice = Alice(
     darkTheme: true,
     showNotification: false,
   );
-  static final BaseOptions dioOptions = BaseOptions(
-      connectTimeout: 5000,
-      receiveTimeout: 10000,
-      sendTimeout: 5000,
-      headers: _headers,
-      responseType: ResponseType.json,
-      contentType: "application/x-www-form-urlencoded",
-      validateStatus: (status) {
-        // 關閉狀態檢測
-        return status <= 500;
-      },
-      responseDecoder: null);
-  Dio dio = Dio(dioOptions);
+
+  static final dioOptions = BaseOptions(
+    connectTimeout: 5000,
+    receiveTimeout: 10000,
+    sendTimeout: 5000,
+    headers: _headers,
+    responseType: ResponseType.json,
+    contentType: "application/x-www-form-urlencoded",
+    validateStatus: (status) => status <= 500,
+    responseDecoder: null,
+  );
+
+  final dio = Dio(dioOptions);
   PersistCookieJar _cookieJar;
-  static final Exception connectorError = Exception("Connector statusCode is not 200");
+
+  static final connectorError = Exception("Connector statusCode is not 200");
 
   DioConnector._privateConstructor();
 
-  static final DioConnector instance = DioConnector._privateConstructor();
+  static final instance = DioConnector._privateConstructor();
 
-  static String _big5Decoder(List<int> responseBytes, RequestOptions options, ResponseBody responseBody) {
-    String result = big5.decode(responseBytes);
-    return result;
-  }
+  static String _big5Decoder(List<int> responseBytes, RequestOptions options, ResponseBody responseBody) =>
+      big5.decode(responseBytes);
 
   Future<void> init() async {
     final List<RegExp> _blockedCookieNamePatterns = [
@@ -74,79 +74,54 @@ class DioConnector {
     }
   }
 
-  void deleteCookies() {
-    _cookieJar.deleteAll();
-  }
+  void deleteCookies() => _cookieJar.deleteAll();
 
   Future<String> getDataByPost(ConnectorParameter parameter) async {
-    try {
-      Response response = await getDataByPostResponse(parameter);
-      if (response.statusCode == HttpStatus.ok) {
-        return response.toString();
-      } else {
-        throw connectorError;
-      }
-    } catch (e) {
-      throw e;
+    final response = await getDataByPostResponse(parameter);
+
+    if (response.statusCode == HttpStatus.ok) {
+      return response.toString().trim();
     }
+
+    throw connectorError;
   }
 
   Future<String> getDataByGet(ConnectorParameter parameter) async {
-    Response response;
-    try {
-      response = await getDataByGetResponse(parameter);
-      if (response.statusCode == HttpStatus.ok) {
-        return response.toString();
-      } else {
-        throw connectorError;
-      }
-    } catch (e) {
-      throw e;
+    final response = await getDataByGetResponse(parameter);
+
+    if (response.statusCode == HttpStatus.ok) {
+      return response.toString().trim();
     }
+
+    throw connectorError;
   }
 
   Future<Map<String, List<String>>> getHeadersByGet(ConnectorParameter parameter) async {
-    Response<ResponseBody> response;
-    try {
-      response = await dio.get<ResponseBody>(
-        parameter.url,
-        options: Options(responseType: ResponseType.stream), // set responseType to `stream`
-      ); //使速度更快
-      if (response.statusCode == HttpStatus.ok) {
-        return response.headers.map;
-      } else {
-        throw connectorError;
-      }
-    } catch (e) {
-      throw e;
+    final response = await dio.get<ResponseBody>(
+      parameter.url,
+      options: Options(responseType: ResponseType.stream), // set responseType to `stream`
+    );
+
+    if (response.statusCode == HttpStatus.ok) {
+      return response.headers.map;
     }
+
+    throw connectorError;
   }
 
   Future<Response> getDataByGetResponse(ConnectorParameter parameter) async {
-    Response response;
-    try {
-      String url = parameter.url;
-      Map<String, String> data = parameter.data;
-      _handleCharsetName(parameter.charsetName);
-      _handleHeaders(parameter);
-      response = await dio.get(url, queryParameters: data);
-      return response;
-    } catch (e) {
-      throw e;
-    }
+    final url = parameter.url;
+    final data = parameter.data;
+    _handleCharsetName(parameter.charsetName);
+    _handleHeaders(parameter);
+    return await dio.get(url, queryParameters: data);
   }
 
   Future<Response> getDataByPostResponse(ConnectorParameter parameter) async {
-    Response response;
-    try {
-      String url = parameter.url;
-      _handleCharsetName(parameter.charsetName);
-      _handleHeaders(parameter);
-      response = await dio.post(url, data: parameter.data);
-      return response;
-    } catch (e) {
-      throw e;
-    }
+    final url = parameter.url;
+    _handleCharsetName(parameter.charsetName);
+    _handleHeaders(parameter);
+    return await dio.post(url, data: parameter.data);
   }
 
   void _handleHeaders(ConnectorParameter parameter) {
@@ -166,24 +141,25 @@ class DioConnector {
     }
   }
 
-  Future<void> download(String url, SavePathCallback savePath,
-      {ProgressCallback progressCallback, CancelToken cancelToken, Map<String, dynamic> header}) async {
+  Future<void> download(
+    String url,
+    SavePathCallback savePath, {
+    ProgressCallback progressCallback,
+    CancelToken cancelToken,
+    Map<String, dynamic> header,
+  }) async {
     await dio
         .downloadUri(Uri.parse(url), savePath,
             onReceiveProgress: progressCallback,
             cancelToken: cancelToken,
-            options: Options(receiveTimeout: 0, headers: header)) //設置不超時
+            options: Options(receiveTimeout: 0, headers: header))
         .catchError((onError, stack) {
       Log.eWithStack(onError.toString(), stack);
       throw onError;
     });
   }
 
-  Map<String, String> get headers {
-    return _headers;
-  }
+  Map<String, String> get headers => _headers;
 
-  PersistCookieJar get cookiesManager {
-    return _cookieJar;
-  }
+  PersistCookieJar get cookiesManager => _cookieJar;
 }

--- a/lib/src/task/iplus/IPlusCourseAnnouncementTask.dart
+++ b/lib/src/task/iplus/IPlusCourseAnnouncementTask.dart
@@ -31,9 +31,6 @@ class IPlusCourseAnnouncementTask extends IPlusSystemTask<List<ISchoolPlusAnnoun
             title: R.current.warning,
             dialogType: DialogType.INFO,
             desc: R.current.iPlusNoThisClass,
-            btnOkOnPress: () {
-              Get.back<bool>(result: false);
-            },
             btnOkText: R.current.sure,
             offCancelBtn: true,
           );

--- a/lib/src/task/iplus/IPlusCourseFileTask.dart
+++ b/lib/src/task/iplus/IPlusCourseFileTask.dart
@@ -1,4 +1,5 @@
 import 'package:awesome_dialog/awesome_dialog.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_app/src/R.dart';
 import 'package:flutter_app/src/connector/ISchoolPlusConnector.dart';
 import 'package:flutter_app/src/model/ischoolplus/CourseFileJson.dart';
@@ -31,14 +32,10 @@ class IPlusCourseFileTask extends IPlusSystemTask<List<CourseFileJson>> {
             title: R.current.warning,
             dialogType: DialogType.INFO,
             desc: R.current.iPlusNoThisClass,
-            btnOkOnPress: () {
-              Get.back<bool>(result: false);
-            },
             btnOkText: R.current.sure,
             offCancelBtn: true,
           );
           return await super.onErrorParameter(parameter);
-          break;
       }
     }
     return status;

--- a/lib/ui/pages/password/CheckPasswordDialog.dart
+++ b/lib/ui/pages/password/CheckPasswordDialog.dart
@@ -4,7 +4,6 @@ import 'package:flutter_app/debug/log/Log.dart';
 import 'package:flutter_app/src/R.dart';
 import 'package:flutter_app/src/store/Model.dart';
 import 'package:get/get.dart';
-import 'package:local_auth/error_codes.dart' as errorCode;
 import 'package:local_auth/local_auth.dart';
 
 class CheckPasswordDialog extends StatefulWidget {
@@ -31,28 +30,16 @@ class _CheckPasswordDialogState extends State<CheckPasswordDialog> {
     try {
       bool didAuthenticate = await localAuthentication.authenticate(
         localizedReason: R.current.checkIdentity,
-        useErrorDialogs: false,
-        biometricOnly: true,
+        options: const AuthenticationOptions(
+          useErrorDialogs: false,
+          biometricOnly: true,
+        ),
       );
       if (didAuthenticate) {
         Get.back<bool>(result: true);
       }
     } on PlatformException catch (e) {
       Log.d(e.code);
-      switch (e.code) {
-        case errorCode.passcodeNotSet:
-          break;
-        case errorCode.lockedOut:
-          break;
-        case errorCode.notAvailable:
-          break;
-        case errorCode.notEnrolled: //NotEnrolled
-          break;
-        case errorCode.otherOperatingSystem:
-          break;
-        case errorCode.permanentlyLockedOut:
-          break;
-      }
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.7"
   build_runner:
     dependency: "direct dev"
     description:
@@ -392,28 +392,28 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.1.4"
+    version: "9.1.5"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0+9"
+    version: "0.4.0+10"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.0"
+    version: "1.14.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -427,63 +427,63 @@ packages:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.6.2"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "11.2.12"
+    version: "11.2.13"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.10"
+    version: "2.2.11"
   firebase_remote_config:
     dependency: "direct main"
     description:
       name: firebase_remote_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   fixnum:
     dependency: transitive
     description:
@@ -509,7 +509,7 @@ packages:
       name: flutter_blurhash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.6"
   flutter_cache_manager:
     dependency: "direct main"
     description:
@@ -678,7 +678,7 @@ packages:
       name: github
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.1.0"
+    version: "9.1.1"
   glob:
     dependency: transitive
     description:
@@ -790,7 +790,28 @@ packages:
       name: local_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.11"
+    version: "2.0.0"
+  local_auth_android:
+    dependency: transitive
+    description:
+      name: local_auth_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  local_auth_ios:
+    dependency: transitive
+    description:
+      name: local_auth_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logger:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "38.0.0"
+    version: "39.0.0"
   after_init:
     dependency: "direct main"
     description:
@@ -28,7 +28,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "4.0.0"
   android_intent:
     dependency: "direct main"
     description:
@@ -105,7 +105,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   build_config:
     dependency: transitive
     description:
@@ -119,21 +119,21 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
+    version: "2.1.10"
   build_runner_core:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.4"
+    version: "8.2.0"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -315,7 +315,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   dbus:
     dependency: transitive
     description:
@@ -584,7 +584,7 @@ packages:
       name: flutter_markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.9+1"
+    version: "0.6.10"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -678,7 +678,7 @@ packages:
       name: github
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.1.1"
+    version: "9.2.0"
   glob:
     dependency: transitive
     description:
@@ -776,7 +776,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.6"
   lints:
     dependency: transitive
     description:
@@ -832,7 +832,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -1208,14 +1208,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   source_span:
     dependency: transitive
     description:
@@ -1236,14 +1236,14 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.1+1"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   device_info: ^2.0.3
   html_unescape: ^2.0.0
   #處理HTML特殊字
-  local_auth: ^1.1.11
+  local_auth: ^2.0.0
   #驗證身分指紋
   version: ^1.2.0
   #版本比較
@@ -55,7 +55,7 @@ dependencies:
   html: ^0.15.0
   #html解析器
   connectivity: ^3.0.6
-  github: ^9.1.0
+  github: ^9.1.1
   clipboard: ^0.1.3
   #剪貼簿
   #----------WebView----------#
@@ -114,11 +114,11 @@ dependencies:
   alice: ^0.2.5
 
   # Firebase
-  firebase_core: ^1.14.0
-  firebase_analytics: ^9.1.4
-  firebase_crashlytics: ^2.6.1
-  firebase_remote_config: ^2.0.3
-  firebase_messaging: ^11.2.12
+  firebase_core: ^1.14.1
+  firebase_analytics: ^9.1.5
+  firebase_crashlytics: ^2.6.2
+  firebase_remote_config: ^2.0.4
+  firebase_messaging: ^11.2.13
 
   http_parser: ^4.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   html: ^0.15.0
   #html解析器
   connectivity: ^3.0.6
-  github: ^9.1.1
+  github: ^9.2.0
   clipboard: ^0.1.3
   #剪貼簿
   #----------WebView----------#
@@ -108,7 +108,7 @@ dependencies:
   #email使用可左右滑抽屜
   flutter_spinkit: ^5.1.0
   #等待動畫
-  flutter_markdown: ^0.6.9+1
+  flutter_markdown: ^0.6.10
   numberpicker: ^2.1.1
   #選擇學期
   alice: ^0.2.5
@@ -128,8 +128,8 @@ dev_dependencies:
     sdk: flutter
   flutter_launcher_icons: ^0.9.2
   #---------json----------#
-  build_runner: ^2.1.8
-  json_serializable: ^6.1.5
+  build_runner: ^2.1.10
+  json_serializable: ^6.1.6
 
 
 flutter:


### PR DESCRIPTION
## Description

The response header `ContentType` from the i-school APIs may has some non-standard values.
for example: `text/html;;`, which contains an illegal `;` after the first `;`.

And this will cause the dio (httpClient) to throw an error, and makes the data parsing steps terminated unexpectedly.

According to #63, we cannot use dio's interceptor to solve this problem, so I create a custom `HttpClientAdapter` and insert it into dio instance to modify the strange header before any interceptors be executed.