### PR TITLE
Fix: profile avatar download error

### DIFF
--- a/lib/src/connector/NTUTConnector.dart
+++ b/lib/src/connector/NTUTConnector.dart
@@ -115,22 +115,16 @@ class NTUTConnector {
     }
   }
 
-  /*
-  Map key
-  url
-  header
-   */
-  static Map getUserImage() {
-    Map imageInfo = Map();
-    String userPhoto = Model.instance.getUserInfo().userPhoto;
+  static Future<Map<String, Map<String, String>>> getUserImageRequestInfo() async {
+    final imageInfo = Map<String, Map<String, String>>();
+    final userPhoto = Model.instance.getUserInfo().userPhoto;
     Log.d("getUserImage");
-    String url = _getPictureUrl;
-    Map<String, String> data = {"realname": userPhoto};
-    if (userPhoto.isNotEmpty) {
-      url = Uri.https(Uri.parse(url).host, Uri.parse(url).path, data).toString();
-    }
-    imageInfo["url"] = url;
-    imageInfo["header"] = Connector.getLoginHeaders(url);
+
+    final url = _getPictureUrl + '?realname=$userPhoto';
+
+    imageInfo['url'] = {'value': url};
+    imageInfo['header'] = await Connector.getLoginHeaders(url);
+
     return imageInfo;
   }
 

--- a/lib/src/connector/NTUTConnector.dart
+++ b/lib/src/connector/NTUTConnector.dart
@@ -27,12 +27,12 @@ enum NTUTConnectorStatus {
 }
 
 class NTUTConnector {
-  static final String host = "https://app.ntut.edu.tw/";
-  static final String _loginUrl = host + "login.do";
-  static final String _getPictureUrl = host + "photoView.do";
-  static final String _getTreeUrl = host + "aptreeList.do";
-  static final String _getCalendarUrl = host + "calModeApp.do";
-  static final String _changePasswordUrl = host + "passwordMdy.do";
+  static const host = "https://app.ntut.edu.tw/";
+  static const _loginUrl = host + "login.do";
+  static const _getPictureUrl = host + "photoView.do";
+  static const _getTreeUrl = host + "aptreeList.do";
+  static const _getCalendarUrl = host + "calModeApp.do";
+  static const _changePasswordUrl = host + "passwordMdy.do";
 
   static Future<NTUTConnectorStatus> login(String account, String password) async {
     try {

--- a/lib/src/connector/core/Connector.dart
+++ b/lib/src/connector/core/Connector.dart
@@ -1,12 +1,5 @@
-//
-//  Connector.dart
-//  北科課程助手
-//
-//  Created by morris13579 on 2020/02/12.
-//  Copyright © 2020 morris13579 All rights reserved.
-//
+import 'dart:io';
 
-import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_app/debug/log/Log.dart';
 import 'package:sprintf/sprintf.dart';
@@ -53,17 +46,19 @@ class Connector {
     }
   }
 
-  static Map<String, String> getLoginHeaders(String url) {
+  static Future<Map<String, String>> getLoginHeaders(String url) async {
     try {
-      PersistCookieJar cookieJar = DioConnector.instance.cookiesManager;
-      Map<String, String> headers = Map.from(DioConnector.instance.headers);
-      headers["Cookie"] = cookieJar.loadForRequest(Uri.parse(url)).toString().replaceAll("[", "").replaceAll("]", "");
-      headers.remove("content-type");
-      //Log.d(headers.toString());
+      final cookieJar = DioConnector.instance.cookiesManager;
+      final headers = Map<String, String>.from(DioConnector.instance.headers);
+      final cookies = await cookieJar.loadForRequest(Uri.parse(url));
+
+      headers[HttpHeaders.cookieHeader] = cookies.first.toString();
+      headers.remove(HttpHeaders.contentTypeHeader);
+
       return headers;
     } catch (e) {
       Log.d(e.toString());
-      return Map();
+      return null;
     }
   }
 

--- a/lib/src/task/iplus/IPlusCourseAnnouncementTask.dart
+++ b/lib/src/task/iplus/IPlusCourseAnnouncementTask.dart
@@ -3,7 +3,6 @@ import 'package:flutter_app/src/R.dart';
 import 'package:flutter_app/src/connector/ISchoolPlusConnector.dart';
 import 'package:flutter_app/src/model/ischoolplus/ISchoolPlusAnnouncementJson.dart';
 import 'package:flutter_app/ui/other/ErrorDialog.dart';
-import 'package:get/get.dart';
 
 import '../Task.dart';
 import 'IPlusSystemTask.dart';

--- a/lib/src/task/iplus/IPlusCourseFileTask.dart
+++ b/lib/src/task/iplus/IPlusCourseFileTask.dart
@@ -1,10 +1,8 @@
 import 'package:awesome_dialog/awesome_dialog.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_app/src/R.dart';
 import 'package:flutter_app/src/connector/ISchoolPlusConnector.dart';
 import 'package:flutter_app/src/model/ischoolplus/CourseFileJson.dart';
 import 'package:flutter_app/ui/other/ErrorDialog.dart';
-import 'package:get/get.dart';
 
 import '../Task.dart';
 import 'IPlusSystemTask.dart';

--- a/lib/ui/pages/other/OtherPage.dart
+++ b/lib/ui/pages/other/OtherPage.dart
@@ -151,8 +151,11 @@ class _OtherPageState extends State<OtherPage> {
       ),
       body: Column(children: <Widget>[
         if (Model.instance.getAccount().isNotEmpty)
-          Container(
-            child: _buildHeader(),
+          SizedBox(
+            child: FutureBuilder<Map<String, Map<String, String>>>(
+              future: NTUTConnector.getUserImageRequestInfo(),
+              builder: (_, snapshot) => snapshot.data != null ? _buildHeader(snapshot.data) : SizedBox.shrink(),
+            ),
           ),
         SizedBox(
           height: 16,

--- a/lib/ui/pages/other/OtherPage.dart
+++ b/lib/ui/pages/other/OtherPage.dart
@@ -225,27 +225,26 @@ class _OtherPageState extends State<OtherPage> {
       givenName = (givenName.isEmpty) ? R.current.pleaseLogin : givenName;
       userMail = (userMail.isEmpty) ? "" : userMail;
     }
-    TaskFlow taskFlow = TaskFlow();
-    var task = NTUTTask("ImageTask");
+    final taskFlow = TaskFlow();
+    final task = NTUTTask("ImageTask");
     task.openLoadingDialog = false;
     taskFlow.addTask(task);
     return Container(
       padding: EdgeInsets.only(top: 24.0, left: 24.0, right: 24.0, bottom: 24.0),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
+        children: [
           Container(
             width: 60,
             height: 60,
             child: InkWell(
               child: FutureBuilder<bool>(
                 future: taskFlow.start(),
-                builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-                  if (snapshot.connectionState == ConnectionState.done && snapshot.data == true) {
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done && snapshot.data) {
                     return userImage;
-                  } else {
-                    return SpinKitRotatingCircle(color: Theme.of(context).colorScheme.secondary);
                   }
+                  return SpinKitRotatingCircle(color: Theme.of(context).colorScheme.secondary);
                 },
               ),
               onTap: () {

--- a/lib/ui/pages/other/OtherPage.dart
+++ b/lib/ui/pages/other/OtherPage.dart
@@ -164,15 +164,13 @@ class _OtherPageState extends State<OtherPage> {
             child: AnimationLimiter(
               child: ListView.builder(
                 itemCount: optionList.length,
-                itemBuilder: (BuildContext context, int index) {
-                  return AnimationConfiguration.staggeredList(
-                    position: index,
-                    duration: const Duration(milliseconds: 375),
-                    child: ScaleAnimation(
-                      child: _buildSetting(optionList[index]),
-                    ),
-                  );
-                },
+                itemBuilder: (context, index) => AnimationConfiguration.staggeredList(
+                  position: index,
+                  duration: const Duration(milliseconds: 375),
+                  child: ScaleAnimation(
+                    child: _buildSetting(optionList[index]),
+                  ),
+                ),
               ),
             ),
           ),

--- a/lib/ui/pages/other/OtherPage.dart
+++ b/lib/ui/pages/other/OtherPage.dart
@@ -198,8 +198,8 @@ class _OtherPageState extends State<OtherPage> {
         return Icon(Icons.error);
       },
     );
-    List<Widget> columnItem = [];
-    final MediaQueryData data = MediaQuery.of(context);
+    final columnItem = <Widget>[];
+    final data = MediaQuery.of(context);
     if (givenName.isNotEmpty) {
       columnItem
         ..add(Text(

--- a/lib/ui/pages/other/OtherPage.dart
+++ b/lib/ui/pages/other/OtherPage.dart
@@ -179,14 +179,13 @@ class _OtherPageState extends State<OtherPage> {
     );
   }
 
-  Widget _buildHeader() {
-    UserInfoJson userInfo = Model.instance.getUserInfo();
+  Widget _buildHeader(Map userImageInfo) {
+    final userInfo = Model.instance.getUserInfo();
     String givenName = userInfo.givenName;
     String userMail = userInfo.userMail;
-    Map userImageInfo = NTUTConnector.getUserImage();
-    Widget userImage = CachedNetworkImage(
+    final userImage = CachedNetworkImage(
       cacheManager: Model.instance.cacheManager,
-      imageUrl: userImageInfo["url"],
+      imageUrl: userImageInfo["url"]["value"],
       httpHeaders: userImageInfo["header"],
       imageBuilder: (context, imageProvider) => CircleAvatar(
         radius: 40.0,

--- a/lib/ui/pages/other/OtherPage.dart
+++ b/lib/ui/pages/other/OtherPage.dart
@@ -7,7 +7,6 @@ import 'package:flutter_app/src/R.dart';
 import 'package:flutter_app/src/config/AppLink.dart';
 import 'package:flutter_app/src/connector/NTUTConnector.dart';
 import 'package:flutter_app/src/file/FileStore.dart';
-import 'package:flutter_app/src/model/userdata/UserDataJson.dart';
 import 'package:flutter_app/src/store/Model.dart';
 import 'package:flutter_app/src/task/TaskFlow.dart';
 import 'package:flutter_app/src/task/ntut/NTUTTask.dart';
@@ -40,7 +39,7 @@ class OtherPage extends StatefulWidget {
 }
 
 class _OtherPageState extends State<OtherPage> {
-  List<Map> optionList = [
+  final optionList = [
     {
       "icon": EvaIcons.settings2Outline,
       "color": Colors.orange,


### PR DESCRIPTION
## Description

The avatar on the `OtherPage` will appear a download error since we have updated the `dio` package version.
The reason why it failed is because the `cookieJar` returns a `Future` when calling `loadForRequest` method. (In `getLoginHeaders` function)

So we should wrap the caller side into a `Future` function, and make the avatar Widget be wrapped into a `FutureBuilder`.

## How to verify?
1. Open the APP
2. ensure logged in.
3. Go to the `OtherPage` and to see if the avatar is shown.
(If it is not, retry sometimes, because it might be affacted by the school API.)

## screenshot
<img height="586" alt="截圖 2022-04-22 上午11 47 51" src="https://user-images.githubusercontent.com/47718989/164594732-f0015b87-318b-456f-94f8-5335d72c93b4.png">