### PR TITLE
Fix debug page color scheme error

### DIFF
--- a/lib/src/connector/core/DioConnector.dart
+++ b/lib/src/connector/core/DioConnector.dart
@@ -23,7 +23,7 @@ class DioConnector {
   };
 
   final alice = Alice(
-    darkTheme: true,
+    // darkTheme: true,
     showNotification: false,
   );
 

--- a/lib/ui/pages/logconsole/log_console.dart
+++ b/lib/ui/pages/logconsole/log_console.dart
@@ -135,7 +135,7 @@ class _LogConsoleState extends State<LogConsole> {
       debugShowCheckedModeBanner: false,
       theme: widget.dark
           ? ThemeData(
-              brightness: Brightness.dark,
+              brightness: Brightness.light,
               colorScheme: ColorScheme.fromSwatch().copyWith(secondary: Colors.blueGrey),
             )
           : ThemeData(
@@ -208,7 +208,7 @@ class _LogConsoleState extends State<LogConsole> {
 
   Widget _buildLogContent() {
     return Container(
-      color: widget.dark ? Colors.black : Colors.grey[150],
+      color: Colors.grey[150],
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: SizedBox(


### PR DESCRIPTION
## Description

The debug screen (Dio log & App log) was using some deprecated theme API when the flutter sdk version is `1.22.6`, but now it is `2.10.5`.

So we just enforce them to use light theme, which is a default theme of `ThemeData` to prevent the theme `brightness` not equal errors.

## How to verify?
- Go to the debug page and to see if it is normal.

## screenshots
<img width="50%" alt="截圖 2022-04-23 下午5 34 05" src="https://user-images.githubusercontent.com/47718989/164889112-e2a3953e-06c2-48d6-81c8-727af7ef8424.png"><img width="50%" alt="截圖 2022-04-23 下午5 34 14" src="https://user-images.githubusercontent.com/47718989/164889118-3f9b70fe-fea6-45a5-83cc-9709fa7fad89.png">

