### PR TITLE
Fix content access not correct when not login ntut

### DIFF
--- a/lib/src/store/local_storage.dart
+++ b/lib/src/store/local_storage.dart
@@ -72,7 +72,7 @@ class LocalStorage {
 
   Future<void> saveUserData() => _save(_userDataJsonKey, _userData);
 
-  Future<void> _clearUserData() {
+  Future<void> clearUserData() {
     _userData = UserDataJson();
     return saveUserData();
   }
@@ -298,7 +298,7 @@ class LocalStorage {
   }
 
   Future<void> logout() async {
-    await _clearUserData();
+    await clearUserData();
     clearSemesterJsonList();
     await clearCourseTableList();
     await _clearCourseScoreCredit();

--- a/lib/ui/other/route_utils.dart
+++ b/lib/ui/other/route_utils.dart
@@ -21,17 +21,15 @@ import 'package:flutter_app/ui/pages/roll_call_remind/zuvio_login_page.dart';
 import 'package:flutter_app/ui/pages/videoplayer/class_video_player.dart';
 import 'package:flutter_app/ui/pages/webview/web_view_page.dart';
 import 'package:flutter_app/ui/screen/login_screen.dart';
+import 'package:flutter_app/ui/screen/main_screen.dart';
 import 'package:get/get.dart';
 
 class RouteUtils {
   static Transition transition = (Platform.isAndroid) ? Transition.downToUp : Transition.cupertino;
 
-  static Future toLoginScreen() async {
-    return await Get.to(
-      () => const LoginScreen(),
-      transition: transition,
-    );
-  }
+  static Future toLoginScreen() => Get.offAll(() => const LoginScreen());
+
+  static Future launchMainPage() => Get.offAll(() => const MainScreen());
 
   static Future toDevPage() async {
     return await Get.to(

--- a/lib/ui/pages/coursetable/course_table_page.dart
+++ b/lib/ui/pages/coursetable/course_table_page.dart
@@ -57,14 +57,15 @@ class _CourseTablePageState extends State<CourseTablePage> {
   void initState() {
     super.initState();
     _studentIdControl.text = " ";
-    UserDataJson userData = LocalStorage.instance.getUserData();
-    Future.delayed(const Duration(milliseconds: 200)).then((_) {
+    final userData = LocalStorage.instance.getUserData();
+
+    Future.delayed(const Duration()).then((_) {
       if (userData.account.isEmpty || userData.password.isEmpty) {
         RouteUtils.toLoginScreen().then((value) {
           if (value != null && value) {
             _loadSetting();
           }
-        }); //尚未登入
+        });
       } else {
         _loadSetting();
       }

--- a/lib/ui/pages/other/other_page.dart
+++ b/lib/ui/pages/other/other_page.dart
@@ -115,9 +115,7 @@ class _OtherPageState extends State<OtherPage> {
             btnOkOnPress: () {
               Get.back();
               TaskFlow.resetLoginStatus();
-              LocalStorage.instance.logout().then((_) {
-                widget.pageController.jumpToPage(0);
-              });
+              LocalStorage.instance.logout().then((_) => RouteUtils.toLoginScreen());
             });
         ErrorDialog(parameter).show();
         break;

--- a/lib/ui/pages/other/page/about_page.dart
+++ b/lib/ui/pages/other/page/about_page.dart
@@ -1,6 +1,7 @@
 // TODO: remove sdk version selector after migrating to null-safety.
 // @dart=2.10
 import 'package:eva_icons_flutter/eva_icons_flutter.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/src/version/app_version.dart';
@@ -96,7 +97,7 @@ class _AboutPageState extends State<AboutPage> {
         Future.delayed(const Duration(seconds: 2)).then((_) {
           pressTime = 0;
         });
-        if (pressTime > 3) {
+        if (pressTime > 3 && kDebugMode) {
           if (!inDevMode) {
             inDevMode = true;
             _addDevListItem();

--- a/lib/ui/pages/other/page/setting_page.dart
+++ b/lib/ui/pages/other/page/setting_page.dart
@@ -2,7 +2,6 @@
 // @dart=2.10
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_app/src/config/app_themes.dart';
 import 'package:flutter_app/src/file/file_store.dart';
@@ -11,7 +10,6 @@ import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/src/store/local_storage.dart';
 import 'package:flutter_app/src/util/language_util.dart';
 import 'package:flutter_app/ui/other/list_view_animator.dart';
-import 'package:flutter_app/ui/other/my_toast.dart';
 import "package:flutter_feather_icons/flutter_feather_icons.dart";
 import 'package:get/get.dart';
 import 'package:provider/provider.dart';
@@ -50,11 +48,7 @@ class _SettingPageState extends State<SettingPage> {
       listViewData.add(_buildOpenExternalVideoSetting());
     }
     listViewData.add(_buildLoadIPlusNewsSetting());
-    listViewData.add(_buildAutoCheckAppVersionSetting());
     listViewData.add(_buildDarkModeSetting());
-    if (Platform.isAndroid) {
-      listViewData.add(_buildFolderPathSetting());
-    }
     return Scaffold(
       appBar: AppBar(
         title: Text(R.current.setting),
@@ -107,28 +101,6 @@ class _SettingPageState extends State<SettingPage> {
             widget.pageController.jumpToPage(0);
             Get.back();
           });
-        });
-      },
-    );
-  }
-
-  Widget _buildAutoCheckAppVersionSetting() {
-    return SwitchListTile.adaptive(
-      contentPadding: const EdgeInsets.all(0),
-      title: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            R.current.autoAppCheck,
-            style: textTitle,
-          ),
-        ],
-      ),
-      value: LocalStorage.instance.getOtherSetting().autoCheckAppUpdate,
-      onChanged: (value) {
-        setState(() {
-          LocalStorage.instance.getOtherSetting().autoCheckAppUpdate = value;
-          LocalStorage.instance.saveOtherSetting();
         });
       },
     );
@@ -210,55 +182,5 @@ class _SettingPageState extends State<SettingPage> {
         });
       },
     );
-  }
-
-  Widget _buildFolderPathSetting() {
-    if (downloadPath.isEmpty) {
-      return Container();
-    } else {
-      return InkWell(
-        child: Container(
-          padding: const EdgeInsets.only(top: 10, bottom: 10),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      R.current.downloadPath,
-                      style: textTitle,
-                    ),
-                  ),
-                ],
-              ),
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      downloadPath,
-                      style: textBody,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-        onTap: () async {
-          String directory = await FilePicker.platform.getDirectoryPath();
-          if (directory == "/" || directory == null) {
-            if (directory == '/') {
-              MyToast.show(R.current.selectDirectoryFail);
-            }
-          } else {
-            await FileStore.setFilePath(directory);
-            setState(() {
-              downloadPath = directory;
-            });
-          }
-        },
-      );
-    }
   }
 }

--- a/lib/ui/screen/login_screen.dart
+++ b/lib/ui/screen/login_screen.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_app/src/config/app_colors.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/src/store/local_storage.dart';
-import 'package:flutter_app/ui/other/my_toast.dart';
-import 'package:get/get.dart';
+import 'package:flutter_app/ui/other/route_utils.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({Key key}) : super(key: key);
@@ -25,20 +24,19 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   void initState() {
-    super.initState();
     _accountControl.text = LocalStorage.instance.getAccount();
-    _passwordControl.text = LocalStorage.instance.getPassword();
+    super.initState();
   }
 
   void _loginPress(BuildContext context) async {
     if (_formKey.currentState.validate()) {
       _passwordFocus.unfocus();
       _accountFocus.unfocus();
-      LocalStorage.instance.setAccount(_accountControl.text.toString());
+      LocalStorage.instance.setAccount(_accountControl.text.toString().trim());
       LocalStorage.instance.setPassword(_passwordControl.text.toString());
       await LocalStorage.instance.saveUserData();
-      MyToast.show(R.current.loginSave);
-      Get.back<bool>(result: true);
+      _passwordControl.clear();
+      RouteUtils.launchMainPage();
     }
   }
 


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
The main page is available for users who does not login, this seems very strange.
So in this PR, I've fix this issue, makes
- required user's login to see the main screen.
- when user login failed, immediately redirect to login screen.
- when user click logout, immediately redirect to login screen.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
Before start: Uninstall the app, then build a new one to your device.
1. login as a real account, make sure you can login and do everything.
2. logout, to see if the login screen is in front of you.
3. type in a fake account, to see if it has moved back to the login screen and shows an error dialog.
4. In Android, click the `back` button to see if the app is direly closed, not just close the login screen.
5. In iOS, continue the step 3, make sure there's no any back button appears in the login screen.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->
<img src="https://user-images.githubusercontent.com/47718989/168480422-20d4e3da-69ef-436b-8df9-1f9c67be0371.jpg" height="300">

