### PR TITLE
Optimize UI for course pages

### DIFF
--- a/lib/ui/pages/coursedetail/course_detail_page.dart
+++ b/lib/ui/pages/coursedetail/course_detail_page.dart
@@ -1,8 +1,6 @@
 // TODO: remove sdk version selector after migrating to null-safety.
 // @dart=2.10
 import 'package:flutter/material.dart';
-import 'package:flutter_app/src/config/app_config.dart';
-import 'package:flutter_app/src/config/app_themes.dart';
 import 'package:flutter_app/src/model/course/course_class_json.dart';
 import 'package:flutter_app/src/model/coursetable/course_table_json.dart';
 import 'package:flutter_app/src/providers/app_provider.dart';
@@ -56,11 +54,8 @@ class _ISchoolPageState extends State<ISchoolPage> with SingleTickerProviderStat
             bool pop = (currentState == null) ? true : currentState.canPop();
             return pop;
           },
-          child: MaterialApp(
-            title: AppConfig.appName,
-            theme: appProvider.theme,
-            darkTheme: AppThemes.darkTheme,
-            home: tabPageView(),
+          child: Container(
+            child: tabPageView(),
           ),
         );
       },
@@ -77,7 +72,7 @@ class _ISchoolPageState extends State<ISchoolPage> with SingleTickerProviderStat
           leading: BackButton(
             onPressed: () => Get.back(),
           ),
-          title: Text(course.name),
+          title: FittedBox(child: Text(course.name)),
           bottom: TabBar(
             indicatorPadding: const EdgeInsets.all(0),
             labelPadding: const EdgeInsets.all(0),

--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -70,10 +70,13 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
     courseData.add(_buildCourseInfo(sprintf("%s: %s", [R.current.courseName, courseMainInfo.course.name])));
     courseData.add(_buildCourseInfo(sprintf("%s: %s    ", [R.current.credit, courseMainInfo.course.credits])));
     courseData.add(_buildCourseInfo(sprintf("%s: %s    ", [R.current.category, courseExtraInfo.course.category])));
-    courseData.add(_buildCourseInfoWithButton(
+    courseData.add(
+      _buildCourseInfoWithButton(
         sprintf("%s: %s", [R.current.instructor, courseMainInfo.getTeacherName()]),
         R.current.syllabus,
-        courseMainInfo.course.scheduleHref));
+        courseMainInfo.course.scheduleHref,
+      ),
+    );
     courseData.add(_buildCourseInfo(sprintf("%s: %s", [R.current.startClass, courseMainInfo.getOpenClassName()])));
     courseData.add(_buildMultiButtonInfo(
       sprintf("%s: ", [R.current.classroom]),
@@ -92,7 +95,12 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
     listItem.addAll(courseData);
     listItem.add(_buildInfoTitle(R.current.studentList));
     for (int i = 0; i < courseExtraInfo.classmate.length; i++) {
-      listItem.add(_buildClassmateInfo(i, widget.courseInfo.extra.classmate[i]));
+      listItem.add(
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 0),
+          child: _buildClassmateInfo(i, widget.courseInfo.extra.classmate[i]),
+        ),
+      );
     }
     isLoading = false;
     setState(() {});
@@ -130,7 +138,10 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
               child: FadeInAnimation(
                 child: GestureDetector(
                   behavior: HitTestBehavior.opaque, //讓透明部分有反應
-                  child: Container(padding: const EdgeInsets.only(left: 20, right: 20), child: listItem[index]),
+                  child: Container(
+                    padding: const EdgeInsets.only(left: 20, right: 20),
+                    child: listItem[index],
+                  ),
                   onTap: () {},
                 ),
               ),
@@ -165,28 +176,23 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
   }
 
   Widget _buildCourseInfoWithButton(String text, String buttonText, String url) {
-    TextStyle textStyle = const TextStyle(fontSize: 18);
     return Container(
       padding: const EdgeInsets.only(bottom: 5),
       child: Row(
-        children: <Widget>[
+        children: [
           const Icon(Icons.details),
           Expanded(
             child: Text(
               text,
-              style: textStyle,
+              style: const TextStyle(fontSize: 18),
             ),
           ),
           (url.isNotEmpty)
               ? ElevatedButton(
-                  child: Text(
-                    buttonText,
-                  ),
-                  onPressed: () {
-                    _launchWebView(buttonText, url);
-                  },
+                  child: Text(buttonText),
+                  onPressed: () => _launchWebView(buttonText, url),
                 )
-              : Container()
+              : const SizedBox.shrink(),
         ],
       ),
     );
@@ -208,42 +214,55 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
   }
 
   Widget _buildMultiButtonInfo(String title, String buttonText, List<String> textList, List<String> urlList) {
-    TextStyle textStyle = const TextStyle(fontSize: 18);
-    List<Widget> classroomItemList = [];
+    const textStyle = TextStyle(fontSize: 18);
+    final classroomItemList = <Widget>[];
+
     for (int i = 0; i < textList.length; i++) {
-      String text = textList[i];
-      classroomItemList.add(Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: <Widget>[
-          Text(
-            text,
-            style: textStyle,
+      final text = textList[i];
+      classroomItemList.add(
+        FittedBox(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                text,
+                style: textStyle,
+              ),
+              const SizedBox(width: 4),
+              urlList[i].isNotEmpty
+                  ? FittedBox(
+                      child: ElevatedButton(
+                        onPressed: () => _launchWebView(buttonText, urlList[i]),
+                        child: Text(buttonText),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ],
           ),
-          urlList[i].isNotEmpty
-              ? ElevatedButton(
-                  onPressed: () {
-                    _launchWebView(buttonText, urlList[i]);
-                  },
-                  child: Text(buttonText),
-                )
-              : Container()
-        ],
-      ));
+        ),
+      );
     }
-    Widget classroomWidget = Column(
-      children: classroomItemList,
-    );
+
     return Container(
       padding: const EdgeInsets.only(bottom: 5),
       child: Row(
-        children: <Widget>[
-          const Icon(Icons.details),
-          Text(
-            title,
-            style: textStyle,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Icon(Icons.details),
+              Text(
+                title,
+                style: textStyle,
+              ),
+            ],
           ),
           Expanded(
-            child: classroomWidget,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: classroomItemList,
+            ),
           ),
         ],
       ),
@@ -251,31 +270,38 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
   }
 
   Widget _buildClassmateInfo(int index, ClassmateJson classmate) {
-    Color color;
-    color = (index % 2 == 1) ? Theme.of(context).backgroundColor : Theme.of(context).dividerColor;
+    final color = (index % 2 == 1) ? Theme.of(context).backgroundColor : Theme.of(context).dividerColor;
     return Container(
-      color: color,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: <Widget>[
           Expanded(
-              child: Text(
-            classmate.className,
-            textAlign: TextAlign.center,
-          )),
+            child: Text(
+              classmate.className,
+              textAlign: TextAlign.center,
+            ),
+          ),
+          const SizedBox(width: 4),
           Expanded(
             child: Text(
               classmate.studentId,
               textAlign: TextAlign.center,
             ),
           ),
+          const SizedBox(width: 4),
           Expanded(
             child: Text(
               classmate.getName(),
               textAlign: TextAlign.center,
             ),
           ),
-          Expanded(
+          const SizedBox(width: 4),
+          FittedBox(
             child: ElevatedButton(
               child: Text(R.current.search),
               onPressed: () {

--- a/lib/ui/pages/coursedetail/tab_page.dart
+++ b/lib/ui/pages/coursedetail/tab_page.dart
@@ -13,10 +13,12 @@ class TabPage {
     tab = Column(
       children: <Widget>[
         Icon(icons),
-        AutoSizeText(
-          title,
-          maxLines: 1,
-          minFontSize: 6,
+        FittedBox(
+          child: AutoSizeText(
+            title,
+            maxLines: 1,
+            minFontSize: 6,
+          ),
         ),
       ],
     );
@@ -55,7 +57,10 @@ class TabPageList {
     for (TabPage tabPage in tabPageList) {
       Widget tabNew = SizedBox(
         width: width,
-        child: tabPage.tab,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 4),
+          child: tabPage.tab,
+        ),
       );
       pages.add(tabNew);
     }

--- a/lib/ui/pages/coursetable/course_table_page.dart
+++ b/lib/ui/pages/coursetable/course_table_page.dart
@@ -594,7 +594,7 @@ class _CourseTablePageState extends State<CourseTablePage> {
       widgetList.add(
         Expanded(
           child: (courseInfo.isEmpty)
-              ? Container()
+              ? const SizedBox.shrink()
               : Card(
                   child: Container(
                     decoration: BoxDecoration(
@@ -611,15 +611,19 @@ class _CourseTablePageState extends State<CourseTablePage> {
                           children: [
                             Align(
                               alignment: Alignment.center,
-                              child: AutoSizeText(
-                                courseInfo.main.course.name,
-                                style: const TextStyle(
-                                  color: Colors.black,
-                                  fontSize: 14,
+                              child: Padding(
+                                padding: const EdgeInsets.all(2),
+                                child: AutoSizeText(
+                                  courseInfo.main.course.name,
+                                  style: const TextStyle(
+                                    color: Colors.black,
+                                    fontSize: 14,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  minFontSize: 6,
+                                  maxLines: 3,
+                                  textAlign: TextAlign.center,
                                 ),
-                                minFontSize: 10,
-                                maxLines: 3,
-                                textAlign: TextAlign.center,
                               ),
                             ),
                           ],


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
Since #86 , the UI has been migrated to Material 3, but that causes some detailed issues.
- course table page block text overflow
- course info page text overflow
- too ugly(?
So here makes some fix for those places.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
- Open ios and aos version's TAT, and go to course table page and course detail page to see if they looks well.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->
(sorry, I have no time to do that...)
