### PR TITLE
Fix some grade info display wrong

### DIFF
--- a/lib/src/connector/score_connector.dart
+++ b/lib/src/connector/score_connector.dart
@@ -124,11 +124,11 @@ class ScoreConnector {
           courseScore.courseScoreList.add(score);
         }
         try {
-          courseScore.averageScore = double.parse(scoreNodes[scoreNodes.length - 4].getElementsByTagName("td")[0].text);
+          courseScore.averageScore = double.parse(scoreNodes[scoreNodes.length - 5].getElementsByTagName("td")[0].text);
           courseScore.performanceScore =
-              double.parse(scoreNodes[scoreNodes.length - 3].getElementsByTagName("td")[0].text);
-          courseScore.totalCredit = double.parse(scoreNodes[scoreNodes.length - 2].getElementsByTagName("td")[0].text);
-          courseScore.takeCredit = double.parse(scoreNodes[scoreNodes.length - 1].getElementsByTagName("td")[0].text);
+              double.parse(scoreNodes[scoreNodes.length - 4].getElementsByTagName("td")[0].text);
+          courseScore.totalCredit = double.parse(scoreNodes[scoreNodes.length - 3].getElementsByTagName("td")[0].text);
+          courseScore.takeCredit = double.parse(scoreNodes[scoreNodes.length - 2].getElementsByTagName("td")[0].text);
         } catch (e) {
           continue;
         } finally {

--- a/lib/src/model/course/course_score_json.dart
+++ b/lib/src/model/course/course_score_json.dart
@@ -8,7 +8,7 @@ import 'package:sprintf/sprintf.dart';
 
 part 'course_score_json.g.dart';
 
-const List<String> constCourseType = [
+const constCourseType = [
   "○", //	  必	部訂共同必修
   "△", //	必	校訂共同必修
   "☆", //	選	共同選修
@@ -29,7 +29,7 @@ class CourseScoreCreditJson {
 
   //利用學期取得課程資訊
   SemesterCourseScoreJson getCourseBySemester(SemesterJson semesterJson) {
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
+    for (final i in semesterCourseScoreList) {
       if (i.semester == semesterJson) {
         return i;
       }
@@ -39,17 +39,19 @@ class CourseScoreCreditJson {
 
   //取得所有課程資訊
   List<CourseScoreInfoJson> getCourseInfoList() {
-    List<CourseScoreInfoJson> courseInfoList = [];
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
+    final courseInfoList = <CourseScoreInfoJson>[];
+
+    for (final i in semesterCourseScoreList) {
       courseInfoList.addAll(i.courseScoreList);
     }
+
     return courseInfoList;
   }
 
   //利用課程id取得課程資訊
   CourseScoreInfoJson getCourseByCourseId(String courseId) {
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
-      for (CourseScoreInfoJson j in i.courseScoreList) {
+    for (final i in semesterCourseScoreList) {
+      for (final j in i.courseScoreList) {
         if (courseId == j.courseId) {
           return j;
         }
@@ -60,32 +62,39 @@ class CourseScoreCreditJson {
 
   //取得所有課程id
   List<String> getCourseIdList() {
-    List<String> courseIdList = [];
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
-      for (CourseScoreInfoJson j in i.courseScoreList) {
+    final courseIdList = <String>[];
+
+    for (final i in semesterCourseScoreList) {
+      for (final j in i.courseScoreList) {
         courseIdList.add(j.courseId);
       }
     }
+
     return courseIdList;
   }
 
   //取得所有學期
   List<SemesterJson> getSemesterList() {
-    List<SemesterJson> value;
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
+    final value = <SemesterJson>[];
+
+    for (final i in semesterCourseScoreList) {
       value.add(i.semester);
     }
+
     return value;
   }
 
   int getCreditByType(String type) {
     int credit = 0;
-    Map<String, List<CourseScoreInfoJson>> result = getCourseByType(type);
-    for (String key in result.keys.toList()) {
-      for (CourseScoreInfoJson j in result[key]) {
+
+    final result = getCourseByType(type);
+
+    for (final key in result.keys.toList()) {
+      for (final j in result[key]) {
         credit += j.credit.toInt();
       }
     }
+
     return credit;
   }
 
@@ -94,11 +103,12 @@ class CourseScoreCreditJson {
   Map<Semester , List<CourseInfoJson> >
   */
   Map<String, List<CourseScoreInfoJson>> getCourseByType(String type) {
-    Map<String, List<CourseScoreInfoJson>> result = {};
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
-      String semester = sprintf("%s-%s", [i.semester.year, i.semester.semester]);
+    final result = <String, List<CourseScoreInfoJson>>{};
+
+    for (final i in semesterCourseScoreList) {
+      final semester = sprintf("%s-%s", [i.semester.year, i.semester.semester]);
       result[semester] = [];
-      for (CourseScoreInfoJson j in i.courseScoreList) {
+      for (final j in i.courseScoreList) {
         if (j.category.contains(type) && j.isPass) {
           result[semester].add(j);
         }
@@ -107,20 +117,19 @@ class CourseScoreCreditJson {
     return result;
   }
 
-  String getSemesterString(SemesterJson semester) {
-    return sprintf("%s-%s", [semester.year, semester.semester]);
-  }
+  String getSemesterString(SemesterJson semester) => sprintf("%s-%s", [semester.year, semester.semester]);
 
   /*
   key
   Map<Semester , List<CourseInfoJson> >
   */
   Map<String, List<CourseScoreInfoJson>> getGeneralLesson() {
-    Map<String, List<CourseScoreInfoJson>> result = {};
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
-      String semester = getSemesterString(i.semester);
+    final result = <String, List<CourseScoreInfoJson>>{};
+
+    for (final i in semesterCourseScoreList) {
+      final semester = getSemesterString(i.semester);
       result[semester] = [];
-      for (CourseScoreInfoJson j in i.courseScoreList) {
+      for (final j in i.courseScoreList) {
         if (j.isGeneralLesson && j.isPass) {
           result[semester].add(j);
         }
@@ -133,11 +142,12 @@ class CourseScoreCreditJson {
   計算外系學分
   */
   Map<String, List<CourseScoreInfoJson>> getOtherDepartmentCourse(String department) {
-    Map<String, List<CourseScoreInfoJson>> result = {};
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
-      String semester = getSemesterString(i.semester);
+    final result = <String, List<CourseScoreInfoJson>>{};
+
+    for (final i in semesterCourseScoreList) {
+      final semester = getSemesterString(i.semester);
       result[semester] = [];
-      for (CourseScoreInfoJson j in i.courseScoreList) {
+      for (final j in i.courseScoreList) {
         if (j.isOtherDepartment(department) && j.isPass) {
           result[semester].add(j);
         }
@@ -148,8 +158,9 @@ class CourseScoreCreditJson {
 
   int getTotalCourseCredit() {
     int credit = 0;
-    for (SemesterCourseScoreJson i in semesterCourseScoreList) {
-      for (CourseScoreInfoJson j in i.courseScoreList) {
+
+    for (final i in semesterCourseScoreList) {
+      for (final j in i.courseScoreList) {
         if (j.isPass) {
           credit += j.credit.toInt();
         }
@@ -172,13 +183,14 @@ class GraduationInformationJson {
   int outerDepartmentMaxCredit; //外系最多承認學分
   Map<String, int> courseTypeMinCredit;
 
-  GraduationInformationJson(
-      {this.lowCredit,
-      this.courseTypeMinCredit,
-      this.outerDepartmentMaxCredit,
-      this.selectYear,
-      this.selectDivision,
-      this.selectDepartment}) {
+  GraduationInformationJson({
+    this.lowCredit,
+    this.courseTypeMinCredit,
+    this.outerDepartmentMaxCredit,
+    this.selectYear,
+    this.selectDivision,
+    this.selectDepartment,
+  }) {
     selectYear = JsonInit.stringInit(selectYear);
     selectDivision = JsonInit.stringInit(selectDivision);
     selectDepartment = JsonInit.stringInit(selectDepartment);
@@ -186,23 +198,20 @@ class GraduationInformationJson {
     outerDepartmentMaxCredit = outerDepartmentMaxCredit ?? 0;
     if (courseTypeMinCredit == null) {
       courseTypeMinCredit = {};
-      for (String type in constCourseType) {
+      for (final type in constCourseType) {
         courseTypeMinCredit[type] = 0;
       }
     }
   }
 
-  bool get isSelect {
-    return !(selectYear.isEmpty | selectDivision.isEmpty | selectDepartment.isEmpty);
-  }
+  bool get isSelect => !(selectYear.isEmpty | selectDivision.isEmpty | selectDepartment.isEmpty);
 
   factory GraduationInformationJson.fromJson(Map<String, dynamic> json) => _$GraduationInformationJsonFromJson(json);
 
   Map<String, dynamic> toJson() => _$GraduationInformationJsonToJson(this);
 
   @override
-  String toString() {
-    return sprintf(
+  String toString() => sprintf(
         "---------selectYear--------     \n%s \n---------selectDivision--------          \n%s \n---------selectDepartment--------      \n%s \n---------lowCredit--------  \n%s \n---------outerDepartmentMacCredit--------     :%s \ncourseTypeMinCredit :%s \n",
         [
           selectYear,
@@ -210,9 +219,9 @@ class GraduationInformationJson {
           selectDepartment,
           lowCredit.toString(),
           outerDepartmentMaxCredit.toString(),
-          courseTypeMinCredit.toString()
-        ]);
-  }
+          courseTypeMinCredit.toString(),
+        ],
+      );
 }
 
 @JsonSerializable()
@@ -226,15 +235,16 @@ class SemesterCourseScoreJson {
   double totalCredit; //修習總學分數
   double takeCredit; //實得學分數
 
-  SemesterCourseScoreJson(
-      {this.semester,
-      this.now,
-      this.averageScore,
-      this.courseScoreList,
-      this.history,
-      this.performanceScore,
-      this.takeCredit,
-      this.totalCredit}) {
+  SemesterCourseScoreJson({
+    this.semester,
+    this.now,
+    this.averageScore,
+    this.courseScoreList,
+    this.history,
+    this.performanceScore,
+    this.takeCredit,
+    this.totalCredit,
+  }) {
     now = now ?? RankJson();
     history = history ?? RankJson();
     courseScoreList = courseScoreList ?? [];
@@ -245,14 +255,17 @@ class SemesterCourseScoreJson {
     takeCredit = takeCredit ?? 0;
   }
 
-  bool get isRankEmpty {
-    return history.isEmpty && now.isEmpty;
-  }
+  bool get isRankEmpty => history.isEmpty && now.isEmpty;
 
   String getAverageScoreString() {
+    if (averageScore != 0) {
+      return averageScore.toString();
+    }
+
     double average = 0;
     double total = 0;
-    for (CourseScoreInfoJson score in courseScoreList) {
+
+    for (final score in courseScoreList) {
       try {
         average += double.parse(score.score) * score.credit;
         total += score.credit;
@@ -260,29 +273,30 @@ class SemesterCourseScoreJson {
         continue;
       }
     }
+
     average /= total;
-    return (averageScore != 0) ? averageScore.toString() : average.toStringAsFixed(2);
+    return average.toStringAsFixed(2);
   }
 
-  String getPerformanceScoreString() {
-    return performanceScore.toString();
-  }
+  String getPerformanceScoreString() => performanceScore.toString();
 
-  String getTakeCreditString() {
-    return takeCredit.toString();
-  }
+  String getTakeCreditString() => takeCredit.toString();
 
   String getTotalCreditString() {
+    if (totalCredit != 0) {
+      return totalCredit.toString();
+    }
+
     double total = 0;
-    for (CourseScoreInfoJson score in courseScoreList) {
+    for (final score in courseScoreList) {
       total += score.credit;
     }
-    return (totalCredit != 0) ? totalCredit.toString() : total.toString();
+
+    return total.toString();
   }
 
   @override
-  String toString() {
-    return sprintf(
+  String toString() => sprintf(
         "---------semester--------     \n%s \n---------now--------          \n%s \n---------history--------      \n%s \n---------courseScore--------  \n%s \naverageScore     :%s \nperformanceScore :%s \ntotalCredit      :%s \ntakeCredit       :%s \n",
         [
           semester.toString(),
@@ -292,9 +306,9 @@ class SemesterCourseScoreJson {
           averageScore.toString(),
           performanceScore.toString(),
           totalCredit.toString(),
-          takeCredit.toString()
-        ]);
-  }
+          takeCredit.toString(),
+        ],
+      );
 
   factory SemesterCourseScoreJson.fromJson(Map<String, dynamic> json) => _$SemesterCourseScoreJsonFromJson(json);
 
@@ -311,14 +325,17 @@ class RankJson {
     department = department ?? RankItemJson();
   }
 
-  bool get isEmpty {
-    return course.isEmpty && department.isEmpty;
-  }
+  bool get isEmpty => course.isEmpty && department.isEmpty;
 
   @override
   String toString() {
-    return sprintf("---------course--------     \n%s \n" "---------department--------          \n%s \n",
-        [course.toString(), department.toString()]);
+    return sprintf(
+      "---------course--------     \n%s \n" "---------department--------          \n%s \n",
+      [
+        course.toString(),
+        department.toString(),
+      ],
+    );
   }
 
   factory RankJson.fromJson(Map<String, dynamic> json) => _$RankJsonFromJson(json);
@@ -338,17 +355,18 @@ class RankItemJson {
     total = total ?? 0;
   }
 
-  bool get isEmpty {
-    return rank == 0 && total == 0 && percentage == 0;
-  }
+  bool get isEmpty => rank == 0 && total == 0 && percentage == 0;
 
   @override
   String toString() {
-    return sprintf("percentage     :%s \nrank           :%s \ntotal          :%s \n", [
-      percentage.toString(),
-      rank.toString(),
-      total.toString(),
-    ]);
+    return sprintf(
+      "percentage     :%s \nrank           :%s \ntotal          :%s \n",
+      [
+        percentage.toString(),
+        rank.toString(),
+        total.toString(),
+      ],
+    );
   }
 
   factory RankItemJson.fromJson(Map<String, dynamic> json) => _$RankItemJsonFromJson(json);
@@ -366,12 +384,17 @@ class CourseScoreInfoJson {
   String openClass;
   String category;
 
-  String get name {
-    return (LanguageUtil.getLangIndex() == LangEnum.en) ? nameEn : nameZh;
-  }
+  String get name => (LanguageUtil.getLangIndex() == LangEnum.en) ? nameEn : nameZh;
 
-  CourseScoreInfoJson(
-      {this.courseId, this.nameZh, this.nameEn, this.score, this.credit, this.category, this.openClass}) {
+  CourseScoreInfoJson({
+    this.courseId,
+    this.nameZh,
+    this.nameEn,
+    this.score,
+    this.credit,
+    this.category,
+    this.openClass,
+  }) {
     courseId = JsonInit.stringInit(courseId);
     nameZh = JsonInit.stringInit(nameZh);
     nameEn = JsonInit.stringInit(nameEn);
@@ -384,8 +407,8 @@ class CourseScoreInfoJson {
   bool get isPass {
     //是否拿到學分
     try {
-      int s = int.parse(score);
-      return (s >= 60) ? true : false;
+      final s = int.parse(score);
+      return s >= 60;
     } catch (e) {
       return false;
     }
@@ -393,38 +416,41 @@ class CourseScoreInfoJson {
 
   bool isOtherDepartment(String department) {
     //是否是跨系選修
-    List<String> containClass = ["最後一哩"]; //包含就是外系
-    List<String> excludeClass = ["體育"]; //包含就不是外系
+    final containClass = ["最後一哩"]; //包含就是外系
+    final excludeClass = ["體育"]; //包含就不是外系
+
     bool isOther;
     isOther = category.contains("△"); //是校內共同必修就不是外系
     if (isOther) return false;
+
     isOther = !openClass.contains(department); //先用開設班級是否是本系判斷
-    for (String key in excludeClass) {
+    for (final key in excludeClass) {
       isOther &= !openClass.contains(key);
     }
-    for (String key in containClass) {
+
+    for (final key in containClass) {
       isOther |= openClass.contains(key);
     }
+
     return isOther;
   }
 
-  bool get isGeneralLesson {
-    //是否是博雅課程
-    return openClass.contains("博雅") || openClass.contains("職通識課程");
-  }
+  // 是否是博雅課程
+  bool get isGeneralLesson => openClass.contains("博雅") || openClass.contains("職通識課程");
 
-  bool get isCoreGeneralLesson {
-    //是否是博雅核心課程
-    return openClass.contains("核心");
-  }
+  // 是否是博雅核心課程
+  bool get isCoreGeneralLesson => openClass.contains("核心");
 
   @override
   String toString() {
-    return sprintf("name           :%s \nscore           :%s \ncredit          :%s \n", [
-      nameZh.toString(),
-      score.toString(),
-      credit.toString(),
-    ]);
+    return sprintf(
+      "name           :%s \nscore           :%s \ncredit          :%s \n",
+      [
+        nameZh.toString(),
+        score.toString(),
+        credit.toString(),
+      ],
+    );
   }
 
   factory CourseScoreInfoJson.fromJson(Map<String, dynamic> json) => _$CourseScoreInfoJsonFromJson(json);

--- a/lib/ui/pages/coursetable/course_table_page.dart
+++ b/lib/ui/pages/coursetable/course_table_page.dart
@@ -152,7 +152,7 @@ class _CourseTablePageState extends State<CourseTablePage> {
 
   @override
   void setState(fn) {
-    if (context != null) {
+    if (mounted && context != null) {
       super.setState(fn);
     }
   }


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
This problem is caused by school API changed.

<img src="https://user-images.githubusercontent.com/47718989/169519764-3c47db48-d4f7-4872-9a8e-a33307094a73.jpg" height="300">

The API has moved the score data elements to another index, so it will throw parse error when we perform some double conversions (content is changed to a non-parsable value).

So in this PR, we just adjust the index to fit the new responses.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
1. Goto grade page.
2. refresh greade
3. see if the `學業成績` has strange value, such as `0.0`, etc.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->
<img width="586" alt="截圖 2022-05-20 下午7 34 54" src="https://user-images.githubusercontent.com/47718989/169520419-c396d0bd-1ed7-40f2-aa24-a455aefe8ece.png">

