### PR TITLE
Refactor IAB with null-safety migrations

### DIFF
--- a/lib/src/config/app_link.dart
+++ b/lib/src/config/app_link.dart
@@ -1,30 +1,30 @@
-// TODO: remove sdk version selector after migrating to null-safety.
-// @dart=2.10
 import 'dart:io';
 
 class AppLink {
   static const String androidAppPackageName = "club.ntut.npc.tat";
-  static const String _playStore = "https://play.google.com/store/apps/details?id=$androidAppPackageName";
-  static const String _appleStore = "https://apps.apple.com/tw/app/id1513875597";
-  static const String githubOwner = "NEO-TAT";
-  static const String githubName = "tat_flutter";
-  static const String gitHub = "https://github.com/$githubOwner/$githubName";
-  static const String feedbackBaseUrl =
-      "https://docs.google.com/forms/d/e/1FAIpQLSc3JFQECAA6HuzqybasZEXuVf8_ClM0UZYFjpPvMwtHbZpzDA/viewform";
+  static const String _playStoreUrl = "https://play.google.com/store/apps/details?id=$androidAppPackageName";
+  static const String _appleStoreUrl = "https://apps.apple.com/tw/app/id1513875597";
 
-  static const String privacyPolicyUrl =
-      "https://raw.githubusercontent.com/$githubOwner/$githubName/dev/privacy-policy.md";
+  static const String githubOwnerName = "NEO-TAT";
+  static const String tatRepoName = "tat_flutter";
 
-  static String feedback(String mainVersion, String log) {
-    Uri url = Uri.https(Uri.parse(feedbackBaseUrl).host, Uri.parse(feedbackBaseUrl).path, {
-      "entry.978972557": (Platform.isAndroid) ? "Android" : "IOS",
-      "entry.823909330": mainVersion,
-      "entry.517392071": log
-    });
-    return url.toString();
-  }
+  static const String tatGitHubRepoUrlString = "https://github.com/$githubOwnerName/$tatRepoName";
+  static const String privacyPolicyUrlString =
+      'https://raw.githubusercontent.com/$githubOwnerName/$tatRepoName/dev/privacy-policy.md';
 
-  static String get storeLink {
-    return (Platform.isAndroid) ? _playStore : _appleStore;
-  }
+  // TODO: set this to be a remote-config.
+  static final feedbackBaseUrl =
+      Uri.parse('https://docs.google.com/forms/d/e/1FAIpQLSc3JFQECAA6HuzqybasZEXuVf8_ClM0UZYFjpPvMwtHbZpzDA/viewform');
+
+  static Uri feedbackUrl(String mainVersion, String log) => Uri.https(
+        feedbackBaseUrl.host,
+        feedbackBaseUrl.path,
+        {
+          "entry.978972557": (Platform.isAndroid) ? "Android" : "IOS",
+          "entry.823909330": mainVersion,
+          "entry.517392071": log,
+        },
+      );
+
+  static String get storeUrlString => (Platform.isAndroid) ? _playStoreUrl : _appleStoreUrl;
 }

--- a/lib/src/version/update/app_update.dart
+++ b/lib/src/version/update/app_update.dart
@@ -83,7 +83,7 @@ class AppUpdate {
   }
 
   static void _openAppStore() async {
-    final url = AppLink.storeLink;
+    final url = AppLink.storeUrlString;
     if (await canLaunchUrl(Uri.parse(url))) {
       await canLaunchUrl(Uri.parse(url));
     }

--- a/lib/ui/other/route_utils.dart
+++ b/lib/ui/other/route_utils.dart
@@ -95,15 +95,13 @@ class RouteUtils {
     );
   }
 
-  static Future toWebViewPage(String title, String url) async {
-    return await Get.to(
-      () => WebViewPage(
-        title: title,
-        url: url,
-      ),
-      transition: transition,
-    );
-  }
+  static Future toWebViewPage({@required String title, @required Uri initialUrl}) => Get.to(
+        () => WebViewPage(
+          title: title,
+          initialUrl: initialUrl,
+        ),
+        transition: transition,
+      );
 
   static Future toLogConsolePage() async {
     return await Get.to(

--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -170,9 +170,16 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
     );
   }
 
-  void _launchWebView(String title, String url) {
+  void _launchWebView(String title, String urlString) {
     canPop = false;
-    RouteUtils.toWebViewPage(title, url).then((value) => canPop = true);
+
+    final url = Uri.tryParse(urlString);
+
+    if (url != null) {
+      RouteUtils.toWebViewPage(title: title, initialUrl: url).then((value) => canPop = true);
+    } else {
+      // TODO: handle exceptions when the url is null. (null means it may caused by the parse process error.)
+    }
   }
 
   Widget _buildCourseInfoWithButton(String text, String buttonText, String url) {

--- a/lib/ui/pages/other/other_page.dart
+++ b/lib/ui/pages/other/other_page.dart
@@ -138,14 +138,10 @@ class _OtherPageState extends State<OtherPage> {
         RouteUtils.toSettingPage(widget.pageController);
         break;
       case OnListViewPress.report:
-        String link = AppLink.feedbackBaseUrl;
-        try {
-          String mainVersion = await AppUpdate.getAppVersion();
-          link = AppLink.feedback(mainVersion, LogConsole.getLog());
-        } catch (e) {
-          0;
-        }
-        RouteUtils.toWebViewPage(R.current.feedback, link);
+        final mainVersion = await AppUpdate.getAppVersion();
+        final link = AppLink.feedbackUrl(mainVersion, LogConsole.getLog());
+
+        RouteUtils.toWebViewPage(title: R.current.feedback, initialUrl: link ?? AppLink.feedbackBaseUrl);
         break;
       case OnListViewPress.rollCallRemind:
         // TODO(TU): update this log to the real feature log.

--- a/lib/ui/pages/other/page/contributors_page.dart
+++ b/lib/ui/pages/other/page/contributors_page.dart
@@ -12,7 +12,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 class ContributorsPage extends StatelessWidget {
   final github = GitHub();
-  final repositorySlug = RepositorySlug(AppLink.githubOwner, AppLink.githubName);
+  final repositorySlug = RepositorySlug(AppLink.githubOwnerName, AppLink.tatRepoName);
 
   ContributorsPage({Key key}) : super(key: key);
 
@@ -44,7 +44,7 @@ class ContributorsPage extends StatelessWidget {
                     Expanded(
                       child: InkWell(
                         onTap: () {
-                          const url = AppLink.gitHub;
+                          const url = AppLink.tatGitHubRepoUrlString;
                           launchUrl(Uri.parse(url));
                         },
                         child: Container(
@@ -64,7 +64,7 @@ class ContributorsPage extends StatelessWidget {
                               Row(
                                 children: const [
                                   Expanded(
-                                    child: Text(AppLink.gitHub),
+                                    child: Text(AppLink.tatGitHubRepoUrlString),
                                   ),
                                 ],
                               ),

--- a/lib/ui/pages/other/page/privacy_policy_page.dart
+++ b/lib/ui/pages/other/page/privacy_policy_page.dart
@@ -19,7 +19,7 @@ class PrivacyPolicyPage extends StatelessWidget {
         title: Text(R.current.PrivacyPolicy),
       ),
       body: FutureBuilder<String>(
-        future: Connector.getDataByGet(ConnectorParameter(AppLink.privacyPolicyUrl)),
+        future: Connector.getDataByGet(ConnectorParameter(AppLink.privacyPolicyUrlString)),
         builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
           if (snapshot.hasData) {
             return Markdown(

--- a/lib/ui/pages/other/page/sub_system_page.dart
+++ b/lib/ui/pages/other/page/sub_system_page.dart
@@ -80,6 +80,14 @@ class _SubSystemPageState extends State<SubSystemPage> {
           ),
           onTap: () async {
             if (ap.type == 'link') {
+              // This step checks if the `ap.urlLink` is a completed url (should has scheme).
+              // Because we don't need to add any prefix such as `NTUTConnector.host` when it is a completed url.
+              final apLinkUrl = Uri.tryParse(ap.urlLink);
+              if (apLinkUrl != null && apLinkUrl.hasScheme) {
+                RouteUtils.toWebViewPage(title: ap.description, initialUrl: apLinkUrl);
+                return;
+              }
+
               final urlString = "${NTUTConnector.host}${ap.urlLink}";
               final url = Uri.tryParse(urlString);
 

--- a/lib/ui/pages/other/page/sub_system_page.dart
+++ b/lib/ui/pages/other/page/sub_system_page.dart
@@ -80,8 +80,14 @@ class _SubSystemPageState extends State<SubSystemPage> {
           ),
           onTap: () async {
             if (ap.type == 'link') {
-              String url = "${NTUTConnector.host}${ap.urlLink}";
-              RouteUtils.toWebViewPage(ap.description, url);
+              final urlString = "${NTUTConnector.host}${ap.urlLink}";
+              final url = Uri.tryParse(urlString);
+
+              if (url != null) {
+                RouteUtils.toWebViewPage(title: ap.description, initialUrl: url);
+              } else {
+                // TODO: handle exceptions when the url is null. (null means it may caused by the parse process error.)
+              }
             } else {
               RouteUtils.toSubSystemPage(ap.description, ap.apDn);
             }

--- a/lib/ui/pages/webview/in_app_webview_callbacks.dart
+++ b/lib/ui/pages/webview/in_app_webview_callbacks.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+typedef OnProgressChanged = void Function(InAppWebViewController controller, int progress);
+typedef OnTitleChanged = void Function(InAppWebViewController controller, String title);
+
+/// Signature for when deciding whether the current page is allowed to be overridden to load with a given request URL.
+///
+/// Returns [NavigationActionPolicy.ALLOW] if the given request URL is allowed to load.
+/// Returns [NavigationActionPolicy.CANCEL] if the given request URL is NOT allowed to load
+/// Returns `null` if this method doesn't want to involve a policy decision and leaves the decision for others to make.
+typedef OnShouldOverrideUrlLoading = Future<NavigationActionPolicy> Function(
+  InAppWebViewController controller,
+  NavigationAction action,
+);
+typedef OnShouldOverrideUrlLoadingExternalUrlHandler = Future<NavigationActionPolicy> Function(
+  InAppWebViewController controller,
+  NavigationAction navigationAction,
+);
+typedef OnUrlLoadingOverriddenByExternalUrl = void Function(String url);
+typedef OnUpdateVisitedHistory = void Function(InAppWebViewController controller, Uri url, bool androidIsReload);
+
+/// A callback which is called when [OnUpdateVisitedHistory] is called.
+typedef ShouldGoBackOnUpdateVisitedHistoryAndDispatchUrl = Function(Uri url);
+typedef DidUpdateVisitedHistory = void Function(InAppWebViewController controller, Uri url);
+typedef OnLoadStart = void Function(InAppWebViewController controller, Uri url);
+typedef OnLoadStop = void Function(InAppWebViewController controller, Uri url);
+typedef OnLoadError = void Function(InAppWebViewController controller, Uri url, int code, String message);
+typedef OnPageCommitVisible = void Function(InAppWebViewController controller, Uri url);
+typedef HandleExternalMerchantPage = Future<NavigationActionPolicy> Function(Uri url);
+typedef OnNavigateToUrl = void Function(String);
+
+/// Signature for callbacks that report that an [InAppWebView] is created.
+typedef InAppWebViewCreatedCallback = void Function(InAppWebViewController controller);

--- a/lib/ui/pages/webview/in_app_webview_callbacks.dart
+++ b/lib/ui/pages/webview/in_app_webview_callbacks.dart
@@ -31,3 +31,6 @@ typedef OnNavigateToUrl = void Function(String);
 
 /// Signature for callbacks that report that an [InAppWebView] is created.
 typedef InAppWebViewCreatedCallback = void Function(InAppWebViewController controller);
+
+/// Signature for callbacks that report an [InAppWebView] has updated its loading progress.
+typedef InAppWebViewProgressChangedCallback = void Function(InAppWebViewController controller, int progress);

--- a/lib/ui/pages/webview/tat_web_view.dart
+++ b/lib/ui/pages/webview/tat_web_view.dart
@@ -7,15 +7,19 @@ class TATWebView extends StatelessWidget {
     super.key,
     required Uri initialUrl,
     InAppWebViewCreatedCallback? onWebViewCreated,
+    InAppWebViewProgressChangedCallback? onProgressChanged,
   })  : _initialUrl = initialUrl,
-        _onWebViewCreated = onWebViewCreated;
+        _onWebViewCreated = onWebViewCreated,
+        _onProgressChanged = onProgressChanged;
 
   final Uri _initialUrl;
   final InAppWebViewCreatedCallback? _onWebViewCreated;
+  final InAppWebViewProgressChangedCallback? _onProgressChanged;
 
   @override
   Widget build(BuildContext context) => InAppWebView(
         initialUrlRequest: URLRequest(url: _initialUrl),
         onWebViewCreated: _onWebViewCreated,
+        onProgressChanged: _onProgressChanged,
       );
 }

--- a/lib/ui/pages/webview/tat_web_view.dart
+++ b/lib/ui/pages/webview/tat_web_view.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/ui/pages/webview/in_app_webview_callbacks.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+class TATWebView extends StatelessWidget {
+  const TATWebView({
+    super.key,
+    required Uri initialUrl,
+    InAppWebViewCreatedCallback? onWebViewCreated,
+  })  : _initialUrl = initialUrl,
+        _onWebViewCreated = onWebViewCreated;
+
+  final Uri _initialUrl;
+  final InAppWebViewCreatedCallback? _onWebViewCreated;
+
+  @override
+  Widget build(BuildContext context) => InAppWebView(
+        initialUrlRequest: URLRequest(url: _initialUrl),
+        onWebViewCreated: _onWebViewCreated,
+      );
+}

--- a/lib/ui/pages/webview/web_view_button_bar.dart
+++ b/lib/ui/pages/webview/web_view_button_bar.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// A simple button action bar for the WebView use.
+///
+/// When any of onPressed callback is `null`, that button will be disabled.
+class WebViewButtonBar extends StatelessWidget {
+  const WebViewButtonBar({
+    super.key,
+    VoidCallback? onBackPressed,
+    VoidCallback? onForwardPressed,
+    VoidCallback? onRefreshPressed,
+  })  : _onBackPressed = onBackPressed,
+        _onForwardPressed = onForwardPressed,
+        _onRefreshPressed = onRefreshPressed;
+
+  final VoidCallback? _onBackPressed;
+  final VoidCallback? _onForwardPressed;
+  final VoidCallback? _onRefreshPressed;
+
+  @override
+  Widget build(BuildContext context) => ButtonBar(
+        alignment: MainAxisAlignment.center,
+        children: [
+          _ControlButton(icon: const Icon(Icons.arrow_back), onPressed: _onBackPressed),
+          _ControlButton(icon: const Icon(Icons.arrow_forward), onPressed: _onForwardPressed),
+          _ControlButton(icon: const Icon(Icons.refresh), onPressed: _onRefreshPressed),
+        ],
+      );
+}
+
+/// A rounded rectangle button for the [WebViewButtonBar] used.
+class _ControlButton extends StatelessWidget {
+  const _ControlButton({
+    required Icon icon,
+    VoidCallback? onPressed,
+  })  : _icon = icon,
+        _onPressed = onPressed;
+
+  final Icon _icon;
+  final VoidCallback? _onPressed;
+
+  @override
+  Widget build(BuildContext context) => ElevatedButton(
+        style: ButtonStyle(
+          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(30.0),
+            ),
+          ),
+        ),
+        onPressed: _onPressed,
+        child: _icon,
+      );
+}

--- a/lib/ui/pages/webview/web_view_page.dart
+++ b/lib/ui/pages/webview/web_view_page.dart
@@ -27,7 +27,7 @@ class _WebViewPageState extends State<WebViewPage> {
   late final InAppWebViewController _controller;
 
   // A value shows the progress of page loading. Range from 0.0 to 1.0.
-  double progress = 0;
+  final progress = ValueNotifier(0.0);
 
   Future<void> setInitialCookies() async {
     final cookies = await cookieJar.loadForRequest(widget._initialUrl);
@@ -50,9 +50,14 @@ class _WebViewPageState extends State<WebViewPage> {
     _controller = controller;
   }
 
+  void _onProgressChanged(int webViewProgress) {
+    progress.value = webViewProgress / 100.0;
+  }
+
   Widget _buildTATWebView() => TATWebView(
         initialUrl: widget._initialUrl,
         onWebViewCreated: _onWebViewCreated,
+        onProgressChanged: (_, progress) => _onProgressChanged(progress),
       );
 
   Widget _buildButtonBar() => WebViewButtonBar(
@@ -61,13 +66,16 @@ class _WebViewPageState extends State<WebViewPage> {
         onRefreshPressed: () => _controller.reload(),
       );
 
-  Widget _buildProgressBar() => SizedBox(
-        child: progress < 1.0
-            ? LinearProgressIndicator(
-                value: progress,
-                color: Colors.greenAccent,
-              )
-            : const SizedBox.shrink(),
+  Widget _buildProgressBar() => ValueListenableBuilder<double>(
+        valueListenable: progress,
+        builder: (_, progress, __) => SizedBox(
+          child: progress < 1.0
+              ? LinearProgressIndicator(
+                  value: progress,
+                  color: Colors.greenAccent,
+                )
+              : const SizedBox.shrink(),
+        ),
       );
 
   @override

--- a/lib/ui/pages/webview/web_view_page.dart
+++ b/lib/ui/pages/webview/web_view_page.dart
@@ -1,14 +1,21 @@
-// TODO: remove sdk version selector after migrating to null-safety.
-// @dart=2.10
+// ignore_for_file: import_of_legacy_library_into_null_safe
+
 import 'package:flutter/material.dart';
 import 'package:flutter_app/src/connector/core/dio_connector.dart';
+import 'package:flutter_app/ui/pages/webview/tat_web_view.dart';
+import 'package:flutter_app/ui/pages/webview/web_view_button_bar.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 class WebViewPage extends StatefulWidget {
-  final String url;
-  final String title;
+  const WebViewPage({
+    super.key,
+    required Uri initialUrl,
+    String? title,
+  })  : _initialUrl = initialUrl,
+        _title = title;
 
-  const WebViewPage({Key key, this.title, this.url}) : super(key: key);
+  final Uri _initialUrl;
+  final String? _title;
 
   @override
   State<WebViewPage> createState() => _WebViewPageState();
@@ -17,133 +24,70 @@ class WebViewPage extends StatefulWidget {
 class _WebViewPageState extends State<WebViewPage> {
   final cookieManager = CookieManager.instance();
   final cookieJar = DioConnector.instance.cookiesManager;
-  InAppWebViewController webView;
-  Uri url = Uri.parse('');
+  late final InAppWebViewController _controller;
+
+  // A value shows the progress of page loading. Range from 0.0 to 1.0.
   double progress = 0;
 
-  Future<bool> setCookies() async {
-    final cookies = await cookieJar.loadForRequest(Uri.parse(widget.url));
+  Future<void> setInitialCookies() async {
+    final cookies = await cookieJar.loadForRequest(widget._initialUrl);
+
     for (final cookie in cookies) {
       await cookieManager.setCookie(
-        url: Uri.parse(widget.url),
+        url: widget._initialUrl,
         name: cookie.name,
         value: cookie.value,
         domain: cookie.domain,
-        path: cookie.path,
+        path: cookie.path ?? '/',
         maxAge: cookie.maxAge,
         isSecure: cookie.secure,
         isHttpOnly: cookie.httpOnly,
       );
     }
-    return true;
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: FutureBuilder<bool>(
-        future: setCookies(),
-        builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-          if (snapshot.hasData) {
-            return SafeArea(
-              child: Column(
-                children: <Widget>[
-                  Container(
-                    child: progress < 1.0 ? LinearProgressIndicator(value: progress) : Container(),
-                  ),
-                  Expanded(
-                    child: InAppWebView(
-                      initialUrlRequest: URLRequest(url: Uri.parse(widget.url)),
-                      initialOptions: InAppWebViewGroupOptions(
-                        crossPlatform: InAppWebViewOptions(),
-                      ),
-                      onWebViewCreated: (InAppWebViewController controller) {
-                        webView = controller;
-                      },
-                      onLoadStart: (InAppWebViewController controller, Uri url) {
-                        setState(() {
-                          this.url = url;
-                        });
-                      },
-                      onLoadStop: (InAppWebViewController controller, Uri url) async {
-                        setState(
-                          () {
-                            this.url = url;
-                          },
-                        );
-                      },
-                      onProgressChanged: (InAppWebViewController controller, int progress) {
-                        setState(
-                          () {
-                            this.progress = progress / 100;
-                          },
-                        );
-                      },
-                    ),
-                  ),
-                  ButtonBar(
-                    alignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      ElevatedButton(
-                        style: ButtonStyle(
-                          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                            RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(30.0),
-                            ),
-                          ),
-                        ),
-                        child: const Icon(Icons.arrow_back),
-                        onPressed: () async {
-                          if (webView != null) {
-                            await webView.goBack();
-                          }
-                        },
-                      ),
-                      ElevatedButton(
-                        style: ButtonStyle(
-                          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                            RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(30.0),
-                            ),
-                          ),
-                        ),
-                        child: const Icon(Icons.arrow_forward),
-                        onPressed: () async {
-                          if (webView != null) {
-                            await webView.goForward();
-                          }
-                        },
-                      ),
-                      ElevatedButton(
-                        style: ButtonStyle(
-                          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                            RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(30.0),
-                            ),
-                          ),
-                        ),
-                        child: const Icon(Icons.refresh),
-                        onPressed: () async {
-                          if (webView != null) {
-                            await webView.reload();
-                          }
-                        },
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            );
-          } else {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
-        },
-      ),
-    );
+  void _onWebViewCreated(InAppWebViewController controller) {
+    _controller = controller;
   }
+
+  Widget _buildTATWebView() => TATWebView(
+        initialUrl: widget._initialUrl,
+        onWebViewCreated: _onWebViewCreated,
+      );
+
+  Widget _buildButtonBar() => WebViewButtonBar(
+        onBackPressed: () => _controller.goBack(),
+        onForwardPressed: () => _controller.goForward(),
+        onRefreshPressed: () => _controller.reload(),
+      );
+
+  Widget _buildProgressBar() => SizedBox(
+        child: progress < 1.0
+            ? LinearProgressIndicator(
+                value: progress,
+                color: Colors.greenAccent,
+              )
+            : const SizedBox.shrink(),
+      );
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          title: Text(widget._title ?? ''),
+        ),
+        body: SafeArea(
+          child: Column(
+            children: [
+              _buildProgressBar(),
+              Expanded(
+                child: FutureBuilder(
+                  future: setInitialCookies(),
+                  builder: (context, snapshot) => _buildTATWebView(),
+                ),
+              ),
+              _buildButtonBar(),
+            ],
+          ),
+        ),
+      );
 }


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
This PR is aim to solve #127 , and also migrate current IAB code to null-safety version.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
- open `資訊系統` in the `OtherPage` and go to `網路狀態` page, see if it shown.
- try other pages in `資訊系統` to see if they works.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->

