### PR TITLE
Refactor Calendar page & Pump flutter version to 3.3.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - cloud_firestore (4.2.0):
+  - cloud_firestore (4.3.1):
     - Firebase/Firestore (= 10.3.0)
     - firebase_core
     - Flutter
@@ -65,26 +65,26 @@ PODS:
   - Firebase/RemoteConfig (10.3.0):
     - Firebase/CoreOnly
     - FirebaseRemoteConfig (~> 10.3.0)
-  - firebase_analytics (10.0.7):
+  - firebase_analytics (10.1.0):
     - Firebase/Analytics (= 10.3.0)
     - firebase_core
     - Flutter
-  - firebase_auth (4.2.0):
+  - firebase_auth (4.2.4):
     - Firebase/Auth (= 10.3.0)
     - firebase_core
     - Flutter
-  - firebase_core (2.4.0):
+  - firebase_core (2.4.1):
     - Firebase/CoreOnly (= 10.3.0)
     - Flutter
-  - firebase_crashlytics (3.0.7):
+  - firebase_crashlytics (3.0.9):
     - Firebase/Crashlytics (= 10.3.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (14.1.4):
+  - firebase_messaging (14.2.1):
     - Firebase/Messaging (= 10.3.0)
     - firebase_core
     - Flutter
-  - firebase_remote_config (3.0.7):
+  - firebase_remote_config (3.0.9):
     - Firebase/RemoteConfig (= 10.3.0)
     - firebase_core
     - Flutter
@@ -232,8 +232,6 @@ PODS:
   - OrderedSet (5.0.0)
   - package_info (0.0.1):
     - Flutter
-  - package_info_plus (0.4.5):
-    - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
   - permission_handler_apple (9.0.4):
@@ -243,8 +241,6 @@ PODS:
   - SDWebImage (5.14.2):
     - SDWebImage/Core (= 5.14.2)
   - SDWebImage/Core (5.14.2)
-  - sensors_plus (0.0.1):
-    - Flutter
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_ios (0.0.1):
@@ -283,10 +279,8 @@ DEPENDENCIES:
   - local_auth_ios (from `.symlinks/plugins/local_auth_ios/ios`)
   - open_filex (from `.symlinks/plugins/open_filex/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
-  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
-  - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
@@ -365,14 +359,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/open_filex/ios"
   package_info:
     :path: ".symlinks/plugins/package_info/ios"
-  package_info_plus:
-    :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_ios:
     :path: ".symlinks/plugins/path_provider_ios/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
-  sensors_plus:
-    :path: ".symlinks/plugins/sensors_plus/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_ios:
@@ -392,19 +382,19 @@ CHECKOUT OPTIONS:
     :tag: 10.3.0
 
 SPEC CHECKSUMS:
-  cloud_firestore: cf019e947a49ebb56ddf4ae7f6f2ca13469da1b1
+  cloud_firestore: 5e5bb98722f66e820bf1aa7b3c98ffc9b2450ffb
   connectivity: c4130b2985d4ef6fd26f9702e886bd5260681467
   device_info: d7d233b645a32c40dfdc212de5cf646ca482f175
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
   file_picker: 817ab1d8cd2da9d2da412a417162deee3500fc95
   Firebase: f92fc551ead69c94168d36c2b26188263860acd9
-  firebase_analytics: fd9cc19a31206f636cb3f7775b4b2ad41f4503d2
-  firebase_auth: 579a0dc15451491cc83fccaa5102296635f24938
-  firebase_core: 6f2f753e316765799d88568232ed59e300ff53db
-  firebase_crashlytics: 4aecad95b85802572a72804e4ca57385357e5255
-  firebase_messaging: 4b60bd563e1d21e3fe91afd398b59d0eda79cc60
-  firebase_remote_config: 7fba03b2c711b07b78c12a832730827a6bee7a74
+  firebase_analytics: 9f3a4cb560a59976b2c48707abae2d4cb94bcb3a
+  firebase_auth: 1a21c9357a8077f5c7e2a28311cd5286a0b8ee75
+  firebase_core: bf59c32d2e53814f558efa20840c1902fa2fe461
+  firebase_crashlytics: a45cced3521640e1e389d8b3662936ea9afd6055
+  firebase_messaging: ee597229fc260f8fa491fa8f2d4a32dfbfa406fa
+  firebase_remote_config: 5007603d4cec2dc1e5016077a7ec36ed93c5041b
   FirebaseABTesting: e6660693429b4663573c82f8d2f1041deff1753a
   FirebaseAnalytics: 036232b6a1e2918e5f67572417be1173576245f3
   FirebaseAuth: 0e415d29d846c1dce2fb641e46f35e9888d9bec6
@@ -432,13 +422,11 @@ SPEC CHECKSUMS:
   open_filex: 6e26e659846ec990262224a12ef1c528bb4edbe4
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
-  package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SDWebImage: b9a731e1d6307f44ca703b3976d18c24ca561e84
-  sensors_plus: 5717760720f7e6acd96fdbd75b7428f5ad755ec2
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:flutter_app/src/config/app_config.dart';
 import 'package:flutter_app/src/config/app_themes.dart';
 import 'package:flutter_app/src/connector/blocked_cookies.dart';
 import 'package:flutter_app/src/connector/interceptors/request_interceptor.dart';
+import 'package:flutter_app/src/controllers/calendar_controller.dart';
 import 'package:flutter_app/src/controllers/zuvio_auth_controller.dart';
 import 'package:flutter_app/src/controllers/zuvio_auto_roll_call_schedule_controller.dart';
 import 'package:flutter_app/src/providers/app_provider.dart';
@@ -130,6 +131,8 @@ Future<void> main() async {
     disableAutoRollCallScheduleUseCase: disableAutoRollCallScheduleUseCase,
   );
 
+  final calendarController = CalendarController();
+
   const webViewPage = WebViewPage();
 
   Future<void> handleAppDetached() async {
@@ -146,6 +149,7 @@ Future<void> main() async {
   Get.put(zRollCallMonitorController);
   Get.put(simpleLoginUseCase);
   Get.put(cookieJar);
+  Get.put(calendarController);
 
   await LocalStorage.instance.init(httpClientInterceptors: apiInterceptors);
 

--- a/lib/src/connector/core/dio_connector.dart
+++ b/lib/src/connector/core/dio_connector.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:alice/alice.dart';
+import 'package:alice_lightweight/alice.dart';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dart_big5/big5.dart';
 import 'package:dio/dio.dart';
@@ -21,7 +21,6 @@ class DioConnector {
 
   final alice = Alice(
     navigatorKey: Get.key,
-    showNotification: false,
   );
 
   static final dioOptions = BaseOptions(

--- a/lib/src/controllers/calendar_controller.dart
+++ b/lib/src/controllers/calendar_controller.dart
@@ -1,0 +1,132 @@
+// ignore_for_file: import_of_legacy_library_into_null_safe
+
+import 'dart:collection';
+
+import 'package:flutter_app/src/model/ntut/ntut_calendar_json.dart';
+import 'package:flutter_app/src/task/ntut/ntut_calendar_task.dart';
+import 'package:flutter_app/src/task/task_flow.dart';
+import 'package:flutter_app/src/util/language_util.dart';
+import 'package:get/get_core/get_core.dart';
+import 'package:get/get_instance/get_instance.dart';
+import 'package:get/get_rx/get_rx.dart';
+import 'package:get/get_state_manager/get_state_manager.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+class CalendarController extends GetxController {
+  static CalendarController get to => Get.find();
+
+  final Map<DateTime, List<NTUTCalendarJson>> knownHolidays = {
+    // TODO: Define the source of holidays in a correct way.
+    // FIXME: The type of holiday should not be `NTUTCalendarJson`.
+  };
+
+  final knownSchoolEvents = LinkedHashMap<DateTime, List<NTUTCalendarJson>>(equals: isSameDay);
+
+  final selectedEvents = <NTUTCalendarJson>[].obs;
+  final calendarFormat = CalendarFormat.month.obs;
+  final focusDay = DateTime.now().toLocal().obs;
+  final selectedDay = DateTime.now().toLocal().obs;
+
+  final firstDay = DateTime(1990);
+  final lastDay = DateTime(2099);
+
+  final _storedMonthSet = <DateTime>{};
+
+  String get currentCalendarLocaleString => (LanguageUtil.getLangIndex() == LangEnum.zh) ? "zh_CN" : "en_US";
+
+  List<NTUTCalendarJson> getEventsFromDay(DateTime day) => knownSchoolEvents[day] ?? const [];
+
+  bool isHoliday(DateTime day) => knownHolidays.containsKey(day);
+
+  bool isSelectingSelectedDay(DateTime day) => isSameDay(selectedDay.value, day);
+
+  void onDaySelected(DateTime selectedDay, DateTime focusedDay) {
+    if (!isSameDay(this.selectedDay.value, selectedDay)) {
+      this.selectedDay.value = selectedDay;
+      focusDay.value = focusedDay;
+      selectedEvents.value = getEventsFromDay(selectedDay);
+      update();
+    }
+  }
+
+  Future<void> onPageChanged(DateTime focusedDay) async {
+    focusDay.value = focusedDay;
+    await _getMonthlyEvents(startTime: focusedDay);
+
+    // change the selected day to the first day of current month.
+    selectedDay.value = DateTime(focusedDay.year, focusedDay.month, 1).toUTCLocal();
+
+    // change the selected events to the first day of current month.
+    selectedEvents.value = getEventsFromDay(selectedDay.value);
+
+    update();
+  }
+
+  void onFormatChanged(CalendarFormat format) {
+    calendarFormat.value = format;
+    update();
+  }
+
+  Future<void> findFirstEventsFromToday() async {
+    final now = DateTime.now();
+
+    // Only preserve the day part of the date.
+    final today = DateTime(now.year, now.month, now.day).toUTCLocal();
+
+    await _getMonthlyEvents(startTime: today);
+    selectedEvents.value = getEventsFromDay(today);
+  }
+
+  /// Get the events of the month of the given [startTime].
+  /// If the [startTime] is not the first day of the month, the [startTime] will be set to the first day of the month.
+  Future<void> _getMonthlyEvents({required DateTime startTime}) async {
+    // Since the backend api only supports monthly query, we need to query the whole month.
+    const fixedEventRequestDay = 1;
+
+    final firstDayOfTargetMonth = DateTime(startTime.year, startTime.month, fixedEventRequestDay);
+    if (_storedMonthSet.contains(firstDayOfTargetMonth)) {
+      return;
+    }
+
+    // Use `zero` to represent the last day of the month.
+    const fixedEventRequestLastDayOfAnyMonth = 0;
+
+    final lastDayOfTargetMonth = DateTime(startTime.year, startTime.month + 1, fixedEventRequestLastDayOfAnyMonth);
+
+    final taskFlow = TaskFlow();
+    final calendarTask = NTUTCalendarTask(firstDayOfTargetMonth, lastDayOfTargetMonth);
+    taskFlow.addTask(calendarTask);
+
+    if (await taskFlow.start()) {
+      final schoolEvents = calendarTask.result;
+      if (schoolEvents == null) {
+        return;
+      }
+
+      for (final nonAddedSchoolEvent in schoolEvents) {
+        final eventTime = nonAddedSchoolEvent.startTime.toLocal();
+        knownSchoolEvents.update(
+          eventTime,
+          (addedEvents) => [...addedEvents, nonAddedSchoolEvent],
+          ifAbsent: () => [nonAddedSchoolEvent],
+        );
+      }
+
+      _storedMonthSet.add(firstDayOfTargetMonth);
+    }
+  }
+}
+
+extension on DateTime {
+  static const taipeiTimeZoneHours = 8;
+
+  /// Convert the [DateTime] to the [DateTime] in the Asia/Taipei time zone.
+  /// You may not use `toLocal()` here, since the `toString()` method of `DateTime` will generate different results with the UTC time's.
+  ///
+  /// In specific terms, UTC time is represented by a 'Z' character that is appended to the string representation of the time.
+  /// For example, if the current time in UTC is 3:00 PM, it might be represented as "15:00Z".
+  ///
+  /// It is important to note that the keys for the `knownSchoolEvents` map use UTC time.
+  /// If a non-UTC time is used in the map query, it may not be able to find the corresponding value.
+  DateTime toUTCLocal() => toUtc().add(const Duration(hours: taipeiTimeZoneHours));
+}

--- a/lib/src/controllers/calendar_controller.dart
+++ b/lib/src/controllers/calendar_controller.dart
@@ -22,10 +22,10 @@ class CalendarController extends GetxController {
 
   final knownSchoolEvents = LinkedHashMap<DateTime, List<NTUTCalendarJson>>(equals: isSameDay);
 
-  final selectedEvents = <NTUTCalendarJson>[].obs;
-  final calendarFormat = CalendarFormat.month.obs;
-  final focusDay = DateTime.now().toLocal().obs;
-  final selectedDay = DateTime.now().toLocal().obs;
+  final selectedEventsRx = <NTUTCalendarJson>[].obs;
+  final calendarFormatRx = CalendarFormat.month.obs;
+  final focusDayRx = DateTime.now().toLocal().obs;
+  final selectedDayRx = DateTime.now().toLocal().obs;
 
   final firstDay = DateTime(1990);
   final lastDay = DateTime(2099);
@@ -38,32 +38,32 @@ class CalendarController extends GetxController {
 
   bool isHoliday(DateTime day) => knownHolidays.containsKey(day);
 
-  bool isSelectingSelectedDay(DateTime day) => isSameDay(selectedDay.value, day);
+  bool isSelectingSelectedDay(DateTime day) => isSameDay(selectedDayRx.value, day);
 
   void onDaySelected(DateTime selectedDay, DateTime focusedDay) {
-    if (!isSameDay(this.selectedDay.value, selectedDay)) {
-      this.selectedDay.value = selectedDay;
-      focusDay.value = focusedDay;
-      selectedEvents.value = getEventsFromDay(selectedDay);
+    if (!isSameDay(selectedDayRx.value, selectedDay)) {
+      selectedDayRx.value = selectedDay;
+      focusDayRx.value = focusedDay;
+      selectedEventsRx.value = getEventsFromDay(selectedDay);
       update();
     }
   }
 
   Future<void> onPageChanged(DateTime focusedDay) async {
-    focusDay.value = focusedDay;
+    focusDayRx.value = focusedDay;
     await _getMonthlyEvents(startTime: focusedDay);
 
     // change the selected day to the first day of current month.
-    selectedDay.value = DateTime(focusedDay.year, focusedDay.month, 1).toUTCLocal();
+    selectedDayRx.value = DateTime(focusedDay.year, focusedDay.month, 1).toUTCLocal();
 
     // change the selected events to the first day of current month.
-    selectedEvents.value = getEventsFromDay(selectedDay.value);
+    selectedEventsRx.value = getEventsFromDay(selectedDayRx.value);
 
     update();
   }
 
   void onFormatChanged(CalendarFormat format) {
-    calendarFormat.value = format;
+    calendarFormatRx.value = format;
     update();
   }
 
@@ -78,7 +78,7 @@ class CalendarController extends GetxController {
     final today = DateTime(now.year, now.month, now.day).toUTCLocal();
 
     await _getMonthlyEvents(startTime: today);
-    selectedEvents.value = getEventsFromDay(today);
+    selectedEventsRx.value = getEventsFromDay(today);
   }
 
   /// Get the events of the month of the given [startTime].

--- a/lib/src/controllers/calendar_controller.dart
+++ b/lib/src/controllers/calendar_controller.dart
@@ -68,6 +68,10 @@ class CalendarController extends GetxController {
   }
 
   Future<void> findFirstEventsFromToday() async {
+    if (_storedMonthSet.isNotEmpty) {
+      return;
+    }
+
     final now = DateTime.now();
 
     // Only preserve the day part of the date.

--- a/lib/src/controllers/calendar_controller.dart
+++ b/lib/src/controllers/calendar_controller.dart
@@ -32,7 +32,7 @@ class CalendarController extends GetxController {
 
   final _storedMonthSet = <DateTime>{};
 
-  String get currentCalendarLocaleString => (LanguageUtil.getLangIndex() == LangEnum.zh) ? "zh_CN" : "en_US";
+  String get currentCalendarLocaleString => (LanguageUtil.getLangIndex() == LangEnum.zh) ? "zh_TW" : "en_US";
 
   List<NTUTCalendarJson> getEventsFromDay(DateTime day) => knownSchoolEvents[day] ?? const [];
 

--- a/lib/src/task/iplus/iplus_course_announcement_task.dart
+++ b/lib/src/task/iplus/iplus_course_announcement_task.dart
@@ -30,7 +30,7 @@ class IPlusCourseAnnouncementTask extends IPlusSystemTask<List<ISchoolPlusAnnoun
         case IPlusReturnStatus.noPermission:
           final parameter = ErrorDialogParameter(
             title: R.current.warning,
-            dialogType: DialogType.INFO,
+            dialogType: DialogType.info,
             desc: R.current.iPlusNoThisClass,
             btnOkText: R.current.sure,
             offCancelBtn: true,

--- a/lib/src/task/iplus/iplus_course_file_task.dart
+++ b/lib/src/task/iplus/iplus_course_file_task.dart
@@ -30,7 +30,7 @@ class IPlusCourseFileTask extends IPlusSystemTask<List<CourseFileJson>> {
         case IPlusReturnStatus.noPermission:
           final parameter = ErrorDialogParameter(
             title: R.current.warning,
-            dialogType: DialogType.INFO,
+            dialogType: DialogType.info,
             desc: R.current.iPlusNoThisClass,
             btnOkText: R.current.sure,
             offCancelBtn: true,

--- a/lib/src/task/ntut/ntut_task.dart
+++ b/lib/src/task/ntut/ntut_task.dart
@@ -58,7 +58,7 @@ class NTUTTask<T> extends DialogTask<T> {
   Future<TaskStatus> _handleConnectorStatus(SimpleLoginResultType status) async {
     final parameter = ErrorDialogParameter(
       desc: "",
-      dialogType: DialogType.WARNING,
+      dialogType: DialogType.warning,
       offCancelBtn: true,
     );
 

--- a/lib/src/util/language_util.dart
+++ b/lib/src/util/language_util.dart
@@ -1,11 +1,12 @@
-// TODO: remove sdk version selector after migrating to null-safety.
-// @dart=2.10
+// ignore_for_file: import_of_legacy_library_into_null_safe
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_app/debug/log/log.dart';
 import 'package:flutter_app/generated/l10n.dart';
 import 'package:flutter_app/src/model/setting/setting_json.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/src/store/local_storage.dart';
+import 'package:get/get_utils/get_utils.dart';
 
 enum LangEnum { en, zh }
 
@@ -31,10 +32,9 @@ class LanguageUtil {
   static Future<void> load(Locale locale) async {
     if (getSupportLocale.contains(locale)) {
       await R.load(locale);
-      String lang = locale2String(locale);
+      final lang = locale2String(locale);
       OtherSettingJson otherSetting = LocalStorage.instance.getOtherSetting();
       if (otherSetting.lang != lang) {
-        //只有不相同時可以載入
         otherSetting.lang = lang;
         LocalStorage.instance.setOtherSetting(otherSetting);
         await LocalStorage.instance.saveOtherSetting();
@@ -48,16 +48,16 @@ class LanguageUtil {
   }
 
   static String locale2String(Locale locale) {
-    String countryCode = locale.countryCode ?? "";
-    String languageCode = locale.languageCode ?? "";
+    final countryCode = locale.countryCode ?? "";
+    final languageCode = locale.languageCode;
     return '${countryCode}_$languageCode';
   }
 
   static Locale string2Locale(String lang) {
     try {
-      String countryCode = lang.split("_")[0];
-      String languageCode = lang.split("_")[1];
-      for (Locale locale in getSupportLocale) {
+      final countryCode = lang.split("_")[0];
+      final languageCode = lang.split("_")[1];
+      for (final locale in getSupportLocale) {
         if (locale.languageCode == languageCode && locale.countryCode == countryCode) {
           return locale;
         }
@@ -71,13 +71,13 @@ class LanguageUtil {
   }
 
   static Future<void> setLangByIndex(LangEnum langEnum) async {
-    Locale locale = getSupportLocale[langEnum.index];
+    final locale = getSupportLocale[langEnum.index];
     await load(locale);
   }
 
   static LangEnum getLangIndex() {
-    OtherSettingJson otherSetting = LocalStorage.instance.getOtherSetting();
-    int index = getSupportLocale.indexOf(string2Locale(otherSetting.lang));
+    final otherSetting = LocalStorage.instance.getOtherSetting();
+    final index = getSupportLocale.indexOf(string2Locale(otherSetting.lang));
     switch (index) {
       case 0:
         return LangEnum.en;

--- a/lib/ui/other/error_dialog.dart
+++ b/lib/ui/other/error_dialog.dart
@@ -34,8 +34,8 @@ class ErrorDialogParameter {
     title ??= R.current.alertError;
     btnOkText ??= R.current.sure;
     btnCancelText ??= R.current.cancel;
-    animType ??= AnimType.BOTTOMSLIDE;
-    dialogType ??= DialogType.ERROR;
+    animType ??= AnimType.bottomSlide;
+    dialogType ??= DialogType.error;
     btnCancelOnPress ??= () => null;
     btnOkOnPress ??= () => null;
     if (offOkBtn) {

--- a/lib/ui/pages/calendar/calendar_page.dart
+++ b/lib/ui/pages/calendar/calendar_page.dart
@@ -51,6 +51,29 @@ class CalendarPage extends StatelessWidget {
             borderRadius: BorderRadius.circular(16.0),
           ),
         ),
+        calendarStyle: const CalendarStyle(
+          isTodayHighlighted: true,
+          selectedDecoration: BoxDecoration(
+            color: Colors.lightBlueAccent,
+            shape: BoxShape.circle,
+          ),
+          selectedTextStyle: TextStyle(color: Colors.white),
+          todayDecoration: BoxDecoration(
+            color: Colors.deepOrange,
+            shape: BoxShape.circle,
+          ),
+          todayTextStyle: TextStyle(color: Colors.white),
+          outsideDaysVisible: false,
+          weekendTextStyle: TextStyle(color: Colors.red),
+          markerDecoration: BoxDecoration(
+            color: Colors.teal,
+            shape: BoxShape.circle,
+          ),
+        ),
+        daysOfWeekStyle: const DaysOfWeekStyle(
+          weekdayStyle: TextStyle(height: 1),
+          weekendStyle: TextStyle(height: 1, color: Colors.red),
+        ),
       );
 
   @override

--- a/lib/ui/pages/calendar/calendar_page.dart
+++ b/lib/ui/pages/calendar/calendar_page.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_app/src/controllers/calendar_controller.dart';
+import 'package:flutter_app/src/model/ntut/ntut_calendar_json.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/ui/pages/calendar/calendar_detail_dialog.dart';
 import 'package:get/get.dart';
@@ -10,25 +11,30 @@ import 'package:table_calendar/table_calendar.dart';
 class CalendarPage extends StatelessWidget {
   const CalendarPage({super.key});
 
-  Widget _buildEventList(CalendarController controller) => ListView(
-        children: controller.selectedEvents
-            .map(
-              (event) => Container(
-                decoration: BoxDecoration(
-                  border: Border.all(width: 0.8),
-                  borderRadius: BorderRadius.circular(12.0),
+  Widget _buildEventList(List<NTUTCalendarJson> selectedEvents) => ListView.builder(
+        itemCount: selectedEvents.length,
+        itemBuilder: (context, index) {
+          final event = selectedEvents[index];
+          return Padding(
+            padding: const EdgeInsets.all(4.0),
+            child: InkWell(
+              customBorder: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: ListTile(
+                title: Text(event.calTitle),
+                shape: RoundedRectangleBorder(
+                  side: const BorderSide(color: Colors.grey),
+                  borderRadius: BorderRadius.circular(12),
                 ),
-                margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-                child: ListTile(
-                  title: Text(event.calTitle),
-                  onTap: () => Get.dialog(
-                    CalendarDetailDialog(calendarDetail: event),
-                    barrierDismissible: true,
-                  ),
+                onTap: () => Get.dialog(
+                  CalendarDetailDialog(calendarDetail: event),
+                  barrierDismissible: true,
                 ),
               ),
-            )
-            .toList(),
+            ),
+          );
+        },
       );
 
   Widget _buildTableCalendar(CalendarController controller) => TableCalendar(
@@ -90,7 +96,7 @@ class CalendarPage extends StatelessWidget {
                 _buildTableCalendar(controller),
                 const SizedBox(height: 16.0),
                 Expanded(
-                  child: _buildEventList(controller),
+                  child: _buildEventList(controller.selectedEvents),
                 ),
               ],
             ),

--- a/lib/ui/pages/calendar/calendar_page.dart
+++ b/lib/ui/pages/calendar/calendar_page.dart
@@ -1,182 +1,77 @@
-// TODO: remove sdk version selector after migrating to null-safety.
-// @dart=2.10
+// ignore_for_file: import_of_legacy_library_into_null_safe
+
 import 'package:flutter/material.dart';
-import 'package:flutter_app/src/model/ntut/ntut_calendar_json.dart';
+import 'package:flutter_app/src/controllers/calendar_controller.dart';
 import 'package:flutter_app/src/r.dart';
-import 'package:flutter_app/src/task/ntut/ntut_calendar_task.dart';
-import 'package:flutter_app/src/task/task_flow.dart';
-import 'package:flutter_app/src/util/language_util.dart';
 import 'package:flutter_app/ui/pages/calendar/calendar_detail_dialog.dart';
 import 'package:get/get.dart';
 import 'package:table_calendar/table_calendar.dart';
 
-class CalendarPage extends StatefulWidget {
-  const CalendarPage({Key key}) : super(key: key);
+class CalendarPage extends StatelessWidget {
+  const CalendarPage({super.key});
 
-  @override
-  State<CalendarPage> createState() => _CalendarPageState();
-}
-
-// Example holidays
-final Map<DateTime, List> _holidays = {
-  /*
-  DateTime(2019, 1, 1): ['New Year\'s Day'],
-  DateTime(2019, 1, 6): ['Epiphany'],
-  DateTime(2019, 2, 14): ['Valentine\'s Day'],
-  DateTime(2019, 4, 21): ['Easter Sunday'],
-  DateTime(2019, 4, 22): ['Easter Monday'],
-  */
-};
-
-class _CalendarPageState extends State<CalendarPage> with TickerProviderStateMixin {
-  Map<DateTime, List> _events = {};
-  List _selectedEvents;
-  AnimationController _animationController;
-  CalendarController _calendarController;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedEvents = [];
-    _calendarController = CalendarController();
-
-    _animationController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 400),
-    );
-
-    _animationController.forward();
-    _addEvent();
-  }
-
-  void _addEvent() async {
-    var selectedDay = DateTime.now();
-    selectedDay = selectedDay.add(const Duration(hours: 8)); //to TW time
-    await _getEvent(selectedDay);
-    for (DateTime time in _events.keys) {
-      //顯示當天事件
-      int diffDays = selectedDay.difference(time).inDays;
-      bool isSame = (diffDays == 0);
-      if (isSame) {
-        _onDaySelected(selectedDay, _events[time], null);
-        break;
-      }
-    }
-  }
-
-  Future<void> _getEvent(DateTime time) async {
-    DateTime startTime = DateTime(time.year, time.month, 1);
-    DateTime endTime = DateTime(time.year, time.month + 1, 1);
-    List<NTUTCalendarJson> eventNTUTs;
-
-    TaskFlow taskFlow = TaskFlow();
-    var calendarTask = NTUTCalendarTask(startTime, endTime);
-    taskFlow.addTask(calendarTask);
-    _events = {};
-    if (await taskFlow.start()) {
-      eventNTUTs = calendarTask.result;
-      _events = {};
-      for (int i = 0; i < eventNTUTs.length; i++) {
-        NTUTCalendarJson eventNTUT = eventNTUTs[i];
-        if (_events.containsKey(eventNTUT.startTime)) {
-          _events[eventNTUT.startTime].add(eventNTUT);
-        } else {
-          _events[eventNTUT.startTime] = [eventNTUT];
-        }
-      }
-    }
-    setState(() {
-      _selectedEvents = [];
-    });
-  }
-
-  @override
-  void dispose() {
-    _animationController.dispose();
-    _calendarController.dispose();
-    super.dispose();
-  }
-
-  void _onDaySelected(DateTime day, List events, List holidays) {
-    setState(() {
-      _selectedEvents = events;
-    });
-  }
-
-  void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) async {
-    await _getEvent(first);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(R.current.calendar),
-      ),
-      body: Column(
-        mainAxisSize: MainAxisSize.max,
-        children: <Widget>[
-          // Switch out 2 lines below to play with TableCalendar's settings
-          //-----------------------
-          _buildTableCalendar(),
-          // _buildTableCalendarWithBuilders(),
-          const SizedBox(height: 8.0),
-          //_buildButtons(),
-          const SizedBox(height: 8.0),
-          Expanded(child: _buildEventList()),
-        ],
-      ),
-    );
-  }
-
-  // Simple TableCalendar configuration (using Styles)
-  Widget _buildTableCalendar() {
-    return TableCalendar(
-      locale: (LanguageUtil.getLangIndex() == LangEnum.zh) ? "zh_CN" : "en_US",
-      calendarController: _calendarController,
-      events: _events,
-      holidays: _holidays,
-      startingDayOfWeek: StartingDayOfWeek.monday,
-      calendarStyle: CalendarStyle(
-        selectedColor: Colors.deepOrange[400],
-        todayColor: Colors.deepOrange[200],
-        markersColor: Colors.brown[700],
-        outsideDaysVisible: false,
-      ),
-      headerStyle: HeaderStyle(
-        formatButtonTextStyle: const TextStyle().copyWith(color: Colors.white, fontSize: 15.0),
-        formatButtonDecoration: BoxDecoration(
-          color: Colors.deepOrange[400],
-          borderRadius: BorderRadius.circular(16.0),
-        ),
-      ),
-      onDaySelected: _onDaySelected,
-      onVisibleDaysChanged: _onVisibleDaysChanged,
-    );
-  }
-
-  Widget _buildEventList() {
-    return ListView(
-      children: _selectedEvents
-          .map(
-            (event) => Container(
-              decoration: BoxDecoration(
-                border: Border.all(width: 0.8),
-                borderRadius: BorderRadius.circular(12.0),
-              ),
-              margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-              child: ListTile(
-                title: Text(event.calTitle),
-                onTap: () {
-                  Get.dialog(
+  Widget _buildEventList(CalendarController controller) => ListView(
+        children: controller.selectedEvents
+            .map(
+              (event) => Container(
+                decoration: BoxDecoration(
+                  border: Border.all(width: 0.8),
+                  borderRadius: BorderRadius.circular(12.0),
+                ),
+                margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                child: ListTile(
+                  title: Text(event.calTitle),
+                  onTap: () => Get.dialog(
                     CalendarDetailDialog(calendarDetail: event),
                     barrierDismissible: true,
-                  );
-                },
+                  ),
+                ),
               ),
+            )
+            .toList(),
+      );
+
+  Widget _buildTableCalendar(CalendarController controller) => TableCalendar(
+        focusedDay: controller.focusDay.value,
+        firstDay: controller.firstDay,
+        lastDay: controller.lastDay,
+        locale: controller.currentCalendarLocaleString,
+        calendarFormat: controller.calendarFormat.value,
+        eventLoader: controller.getEventsFromDay,
+        holidayPredicate: controller.isHoliday,
+        selectedDayPredicate: controller.isSelectingSelectedDay,
+        startingDayOfWeek: StartingDayOfWeek.monday,
+        onFormatChanged: controller.onFormatChanged,
+        onDaySelected: controller.onDaySelected,
+        onPageChanged: controller.onPageChanged,
+        headerStyle: HeaderStyle(
+          formatButtonTextStyle: const TextStyle().copyWith(color: Colors.white, fontSize: 15.0),
+          formatButtonDecoration: BoxDecoration(
+            color: Colors.deepOrange[400],
+            borderRadius: BorderRadius.circular(16.0),
+          ),
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) => FutureBuilder(
+        future: CalendarController.to.findFirstEventsFromToday(),
+        builder: (_, __) => Scaffold(
+          appBar: AppBar(
+            title: Text(R.current.calendar),
+          ),
+          body: GetBuilder<CalendarController>(
+            builder: (controller) => Column(
+              mainAxisSize: MainAxisSize.max,
+              children: [
+                _buildTableCalendar(controller),
+                const SizedBox(height: 16.0),
+                Expanded(
+                  child: _buildEventList(controller),
+                ),
+              ],
             ),
-          )
-          .toList(),
-    );
-  }
+          ),
+        ),
+      );
 }

--- a/lib/ui/pages/calendar/calendar_page.dart
+++ b/lib/ui/pages/calendar/calendar_page.dart
@@ -38,11 +38,11 @@ class CalendarPage extends StatelessWidget {
       );
 
   Widget _buildTableCalendar(CalendarController controller) => TableCalendar(
-        focusedDay: controller.focusDay.value,
+        focusedDay: controller.focusDayRx.value,
         firstDay: controller.firstDay,
         lastDay: controller.lastDay,
         locale: controller.currentCalendarLocaleString,
-        calendarFormat: controller.calendarFormat.value,
+        calendarFormat: controller.calendarFormatRx.value,
         eventLoader: controller.getEventsFromDay,
         holidayPredicate: controller.isHoliday,
         selectedDayPredicate: controller.isSelectingSelectedDay,
@@ -96,7 +96,7 @@ class CalendarPage extends StatelessWidget {
                 _buildTableCalendar(controller),
                 const SizedBox(height: 16.0),
                 Expanded(
-                  child: _buildEventList(controller.selectedEvents),
+                  child: _buildEventList(controller.selectedEventsRx),
                 ),
               ],
             ),

--- a/lib/ui/pages/coursedetail/screen/ischoolplus/iplus_file_page.dart
+++ b/lib/ui/pages/coursedetail/screen/ischoolplus/iplus_file_page.dart
@@ -244,7 +244,7 @@ class _IPlusFilePage extends State<IPlusFilePage> with AutomaticKeepAliveClientM
       //代表可能是一個連結
       ErrorDialogParameter errorDialogParameter = ErrorDialogParameter(context: context, desc: R.current.isALink);
       errorDialogParameter.title = R.current.AreYouSureToOpen;
-      errorDialogParameter.dialogType = DialogType.INFO;
+      errorDialogParameter.dialogType = DialogType.info;
       errorDialogParameter.btnOkText = R.current.sure;
       errorDialogParameter.btnOkOnPress = () {
         _launchURL(url);
@@ -257,7 +257,7 @@ class _IPlusFilePage extends State<IPlusFilePage> with AutomaticKeepAliveClientM
         desc: '${R.current.isVideo}\n${R.current.videoMayLoadFailedWarningMsg}',
       );
       errorDialogParameter.title = R.current.AreYouSureToOpen;
-      errorDialogParameter.dialogType = DialogType.INFO;
+      errorDialogParameter.dialogType = DialogType.info;
       errorDialogParameter.btnOkText = R.current.sure;
       errorDialogParameter.btnOkOnPress =
           () => RouteUtils.toVideoPlayer(urlParse.toString(), widget.courseInfo, courseFile.name);

--- a/lib/ui/pages/other/other_page.dart
+++ b/lib/ui/pages/other/other_page.dart
@@ -111,7 +111,7 @@ class _OtherPageState extends State<OtherPage> {
         ErrorDialogParameter parameter = ErrorDialogParameter(
             context: context,
             desc: R.current.logoutWarning,
-            dialogType: DialogType.WARNING,
+            dialogType: DialogType.warning,
             title: R.current.warning,
             btnOkText: R.current.sure,
             btnOkOnPress: () {
@@ -161,7 +161,7 @@ class _OtherPageState extends State<OtherPage> {
           ErrorDialog(ErrorDialogParameter(
             desc: R.current.zuvioAutoRollCallFeatureReleaseNotice,
             title: R.current.comingSoon,
-            dialogType: DialogType.INFO,
+            dialogType: DialogType.info,
             offCancelBtn: true,
             btnOkText: R.current.sure,
           )).show();

--- a/lib/ui/pages/roll_call_remind/new_roll_call_monitor_card_widget.dart
+++ b/lib/ui/pages/roll_call_remind/new_roll_call_monitor_card_widget.dart
@@ -53,7 +53,7 @@ class _NewRollCallMonitorCardState extends State<NewRollCallMonitorCard> {
     final hasStartTime = _monitoringStartTime.value != null;
     if (!hasStartTime) {
       ErrorDialog(ErrorDialogParameter(
-        dialogType: DialogType.WARNING,
+        dialogType: DialogType.warning,
         title: R.current.missingRequiredInformation,
         desc: R.current.pleaseSelectStartTime,
         btnOkText: R.current.sure,
@@ -65,7 +65,7 @@ class _NewRollCallMonitorCardState extends State<NewRollCallMonitorCard> {
     final hasEndTime = _monitoringEndTime.value != null;
     if (!hasEndTime) {
       ErrorDialog(ErrorDialogParameter(
-        dialogType: DialogType.WARNING,
+        dialogType: DialogType.warning,
         title: R.current.missingRequiredInformation,
         desc: R.current.pleaseSelectEndTime,
         btnOkText: R.current.sure,
@@ -77,7 +77,7 @@ class _NewRollCallMonitorCardState extends State<NewRollCallMonitorCard> {
     final hasWeekDay = _selectedWeekdays.value.any((selection) => selection);
     if (!hasWeekDay) {
       ErrorDialog(ErrorDialogParameter(
-        dialogType: DialogType.WARNING,
+        dialogType: DialogType.warning,
         title: R.current.missingRequiredInformation,
         desc: R.current.pleaseSelectWeekday,
         btnOkText: R.current.sure,
@@ -90,7 +90,7 @@ class _NewRollCallMonitorCardState extends State<NewRollCallMonitorCard> {
 
     if (timeInMinuteOf(_monitoringStartTime.value) > timeInMinuteOf(_monitoringEndTime.value)) {
       ErrorDialog(ErrorDialogParameter(
-        dialogType: DialogType.WARNING,
+        dialogType: DialogType.warning,
         title: R.current.incorrectInformationEntered,
         desc: R.current.endTimeMustBeAfterStartTime,
         btnOkText: R.current.sure,

--- a/lib/ui/pages/roll_call_remind/scheduled_roll_call_monitor_card_widget.dart
+++ b/lib/ui/pages/roll_call_remind/scheduled_roll_call_monitor_card_widget.dart
@@ -121,7 +121,7 @@ class ScheduledRollCallMonitorCard extends StatelessWidget {
   Widget _buildRemoveMonitorButton() => ElevatedButton(
         onPressed: () {
           ErrorDialog(ErrorDialogParameter(
-            dialogType: DialogType.QUESTION,
+            dialogType: DialogType.question,
             title: '',
             desc: 'Do you really want to remove this scheduled roll-call remind?',
             btnOkText: R.current.sure,
@@ -158,7 +158,7 @@ class ScheduledRollCallMonitorCard extends StatelessWidget {
           final isSuccess = await _onRollCallPressed();
           if (isSuccess) {
             ErrorDialog(ErrorDialogParameter(
-              dialogType: DialogType.SUCCES,
+              dialogType: DialogType.success,
               title: 'RollCall Success',
               desc: 'You have roll-called to $_courseName.',
               btnOkText: R.current.sure,
@@ -166,7 +166,7 @@ class ScheduledRollCallMonitorCard extends StatelessWidget {
             )).show();
           } else {
             ErrorDialog(ErrorDialogParameter(
-              dialogType: DialogType.ERROR,
+              dialogType: DialogType.error,
               title: 'RollCall Failed',
               desc: 'Failed to roll-called to $_courseName, please try again.',
               btnOkText: R.current.sure,

--- a/lib/ui/pages/webview/web_view_page.dart
+++ b/lib/ui/pages/webview/web_view_page.dart
@@ -46,7 +46,7 @@ class WebViewPage {
           ErrorDialog(ErrorDialogParameter(
             desc: R.current.alertError,
             title: R.current.error,
-            dialogType: DialogType.ERROR,
+            dialogType: DialogType.error,
             offCancelBtn: true,
             btnOkText: R.current.sure,
           )).show();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -22,13 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
-  alice:
+  alice_lightweight:
     dependency: "direct main"
     description:
-      name: alice
+      name: alice_lightweight
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2"
+    version: "3.2.0"
   analyzer:
     dependency: transitive
     description:
@@ -197,13 +197,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.6"
-  chopper:
-    dependency: transitive
-    description:
-      name: chopper
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -614,14 +607,14 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "12.0.4"
+    version: "13.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
@@ -976,7 +969,7 @@ packages:
     source: hosted
     version: "1.0.2"
   open_filex:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: open_filex
       url: "https://pub.dartlang.org"
@@ -996,20 +989,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
-  package_info_plus:
-    dependency: transitive
-    description:
-      name: package_info_plus
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.2"
-  package_info_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: package_info_plus_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.1"
   path:
     dependency: "direct main"
     description:
@@ -1192,20 +1171,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.7"
-  sensors_plus:
-    dependency: transitive
-    description:
-      name: sensors_plus
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.1"
-  sensors_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: sensors_plus_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.3"
   share_plus:
     dependency: transitive
     description:
@@ -1415,7 +1380,7 @@ packages:
       name: timezone
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: _flutterfire_internals
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.11"
+    version: "1.0.12"
   after_init:
     dependency: "direct main"
     description:
@@ -224,21 +224,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.3.1"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.10.0"
+    version: "5.10.1"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   code_builder:
     dependency: transitive
     description:
@@ -427,49 +427,49 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.0.8"
+    version: "10.1.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.16"
+    version: "3.3.17"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1+7"
+    version: "0.5.1+8"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.11.6"
+    version: "6.11.7"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.3"
+    version: "5.2.4"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -483,63 +483,63 @@ packages:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.9"
+    version: "3.3.10"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.2.0"
+    version: "14.2.1"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.9"
+    version: "4.2.10"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.10"
+    version: "3.2.11"
   firebase_remote_config:
     dependency: "direct main"
     description:
       name: firebase_remote_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.28"
+    version: "1.1.29"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.17"
+    version: "1.1.18"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: _flutterfire_internals
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.10"
+    version: "1.0.11"
   after_init:
     dependency: "direct main"
     description:
@@ -77,7 +77,7 @@ packages:
       name: awesome_dialog
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.2"
   back_button_interceptor:
     dependency: "direct main"
     description:
@@ -133,7 +133,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
@@ -231,28 +231,28 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.9.1"
+    version: "5.10.0"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.2.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
@@ -434,42 +434,42 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.15"
+    version: "3.3.16"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1+6"
+    version: "0.5.1+7"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.3"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.11.4"
+    version: "6.11.6"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.2.3"
   firebase_core:
     dependency: "direct main"
     description:
@@ -497,56 +497,56 @@ packages:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.7"
+    version: "3.0.8"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.8"
+    version: "3.3.9"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.1.4"
+    version: "14.2.0"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.8"
+    version: "4.2.9"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.9"
+    version: "3.2.10"
   firebase_remote_config:
     dependency: "direct main"
     description:
       name: firebase_remote_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.7"
+    version: "3.0.8"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.27"
+    version: "1.1.28"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.16"
+    version: "1.1.17"
   fixnum:
     dependency: transitive
     description:
@@ -554,13 +554,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
-  flare_flutter:
-    dependency: transitive
-    description:
-      name: flare_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -600,7 +593,7 @@ packages:
       name: flutter_inappwebview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.7.2+2"
+    version: "5.7.2+3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -822,12 +815,12 @@ packages:
     source: hosted
     version: "1.1.0"
   intl:
-    dependency: "direct main"
+    dependency: "direct overridden"
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.0"
   io:
     dependency: transitive
     description:
@@ -869,28 +862,28 @@ packages:
       name: local_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   local_auth_android:
     dependency: transitive
     description:
       name: local_auth_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.15"
+    version: "1.0.17"
   local_auth_ios:
     dependency: transitive
     description:
       name: local_auth_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.10"
+    version: "1.0.12"
   local_auth_platform_interface:
     dependency: transitive
     description:
       name: local_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   local_auth_windows:
     dependency: transitive
     description:
@@ -1163,7 +1156,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.4"
+    version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -1185,6 +1178,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  rive:
+    dependency: transitive
+    description:
+      name: rive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.1"
   rxdart:
     dependency: "direct main"
     description:
@@ -1247,7 +1247,7 @@ packages:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -1275,7 +1275,7 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shelf:
     dependency: transitive
     description:
@@ -1290,20 +1290,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
-  simple_animations:
-    dependency: transitive
-    description:
-      name: simple_animations
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.2.0"
   simple_gesture_detector:
     dependency: transitive
     description:
       name: simple_gesture_detector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.6"
+    version: "0.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1392,13 +1385,13 @@ packages:
       name: table_calendar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "3.0.8"
   tat_core:
     dependency: "direct main"
     description:
       path: "."
       ref: main
-      resolved-ref: d6376d5594868f4c8097e945ece84c360101398b
+      resolved-ref: fb61b8ec657281241ca92cbed7ee661558d76545
       url: "git@github.com:NTUT-NPC/TAT-Core.git"
     source: git
     version: "1.0.0-4.0.pre"
@@ -1527,35 +1520,35 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.9"
+    version: "2.4.10"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.9"
+    version: "2.3.10"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.8"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.4"
+    version: "6.0.1"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.13"
   wakelock:
     dependency: transitive
     description:
@@ -1618,7 +1611,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -1641,5 +1634,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.5 <3.0.0"
-  flutter: ">=3.3.9"
+  dart: ">=2.18.6 <3.0.0"
+  flutter: ">=3.3.10"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -101,9 +101,9 @@ dependency_overrides:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
   flutter_launcher_icons: ^0.11.0
   flutter_native_splash: ^2.2.16
-  #---------json----------#
   build_runner: ^2.3.3
   json_serializable: ^6.5.4
   flutter_lints: ^2.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   logger: ^1.1.0
   #顯示Log
   sprintf: ^7.0.0
-  flutter_local_notifications: ^12.0.4 # restricted by alice 0.3.x
+  flutter_local_notifications: ^13.0.0
   #通知欄  需修改android原始碼
   rxdart: ^0.27.7
   #通知欄有使用到
@@ -122,7 +122,8 @@ dependencies:
   flutter_markdown: ^0.6.13
   numberpicker: ^2.1.1
   #選擇學期
-  alice: ^0.3.2
+  alice_lightweight: ^3.2.0
+  open_filex: ^4.3.2
 
   # Firebase
   firebase_core: ^2.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,107 +25,68 @@ dependencies:
       url: git@github.com:NTUT-NPC/TAT-Core.git
       ref: main
 
-  path: ^1.8.2 # restricted by flutter sdk.
+  path: 1.8.2 # restricted by flutter sdk.
   path_provider: ^2.0.11
   provider: ^6.0.5
   url_launcher: ^6.1.7
-  #開啟email phone url...
   logger: ^1.1.0
-  #顯示Log
   sprintf: ^7.0.0
   flutter_local_notifications: ^13.0.0
-  #通知欄  需修改android原始碼
   rxdart: ^0.27.7
-  #通知欄有使用到
   video_player: ^2.4.10
   chewie: ^1.3.6
   after_init: ^0.1.2
   android_intent: ^2.0.2
   device_info: ^2.0.3
   html_unescape: ^2.0.0
-  #處理HTML特殊字
   local_auth: ^2.1.3
-  #驗證身分指紋
   version: ^3.0.2
-  #版本比較
   file_picker: ^5.2.4
-  #選擇android資料夾
-  #----------store data----------#
   shared_preferences: ^2.0.15
   flutter_cache_manager: ^3.3.0
-  #----------internet----------#
   dio: ^4.0.6
-  #網路get post API
   dio_cookie_manager: ^2.0.0
-  #用於產生cookie_jar與dio接口
   cookie_jar: ^3.0.1
-  #可儲存式cookies
   html: ^0.15.1
-  #html解析器
   connectivity: ^3.0.6
   github: ^9.7.0
   clipboard: ^0.1.3
-  #剪貼簿
-  #----------WebView----------#
   flutter_inappwebview: ^5.7.2+3
   flutter_web_browser:
     git:
       url: git@github.com:NEO-TAT/flutter_web_browser.git
       ref: master
-  #---------icon----------#
   eva_icons_flutter: ^3.1.0
-  #https://akveo.github.io/eva-icons/#/
-
   flutter_feather_icons: ^2.0.0+1
-  #https://oblador.github.io/react-native-vector-icons/
-  #---------json----------#
   json_annotation: ^4.7.0
-  #----------other----------#
   back_button_interceptor: ^6.0.2
-  #攔截返回鍵訊息
   dart_big5: ^0.0.5
-
-  #DateTime to String
   package_info: ^2.0.2
-  #檢測app版本用於檢查更新
-  #----------html viewer----------#
   flutter_widget_from_html_core: ^0.9.0+2
-  #----------animation----------#
   flutter_staggered_animations: ^1.1.1
-  #listView or gridView動畫
-  #----------download----------#
   flutter_downloader: ^1.9.1
-  #下載app更新
   permission_handler: ^10.2.0
   mime_type: ^1.0.0
-  #----------Widget----------#
   get: ^4.6.5
   bot_toast: ^4.0.3
   pull_to_refresh: ^2.0.0
-  #提供ListView可下拉式更新並且可動態加載
   cached_network_image: ^3.2.3
-  #用url顯示圖片
   auto_size_text: ^3.0.0
-  #課表顯示有用到
-  table_calendar: ^3.0.8 # force version
-  #顯示行事曆
+  table_calendar: ^3.0.8
   flutter_xlider: ^3.4.0
-  #語言切換用
   fluttertoast: ^8.1.2
-  #Toast
-  awesome_dialog: ^3.0.2 # force version
-  #顯示Error時用到
+  awesome_dialog: ^3.0.2
   flutter_slidable: ^2.0.0
-  #email使用可左右滑抽屜
   flutter_spinkit: ^5.1.0
-  #等待動畫
   flutter_markdown: ^0.6.13
   numberpicker: ^2.1.1
-  #選擇學期
   alice_lightweight: ^3.2.0
   open_filex: ^4.3.2
+  http_parser: ^4.0.2
+  modal_bottom_sheet: ^2.1.2
+  email_validator: ^2.1.17
+  weekday_selector: ^1.1.0
 
-  # Firebase
   firebase_core: ^2.4.0
   firebase_analytics: ^10.0.8
   firebase_crashlytics: ^3.0.8
@@ -133,13 +94,6 @@ dependencies:
   firebase_messaging: ^14.2.0
   cloud_firestore: ^4.3.0
   firebase_auth: ^4.2.3
-
-  http_parser: ^4.0.2
-
-  modal_bottom_sheet: ^2.1.2
-  email_validator: ^2.1.17
-
-  weekday_selector: ^1.1.0
 
 dependency_overrides:
   intl: ^0.18.0
@@ -153,7 +107,6 @@ dev_dependencies:
   build_runner: ^2.3.3
   json_serializable: ^6.5.4
   flutter_lints: ^2.0.1
-
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ publish_to: 'none'
 version: 1.4.2+5016
 
 environment:
-  flutter: ">=3.3.9 <4.0.0"
-  sdk: ">=2.18.5 <3.0.0"
+  flutter: ">=3.3.10 <4.0.0"
+  sdk: ">=2.18.6 <3.0.0"
 
 dependencies:
   flutter:
@@ -27,24 +27,24 @@ dependencies:
 
   path: ^1.8.2 # restricted by flutter sdk.
   path_provider: ^2.0.11
-  provider: ^6.0.4
+  provider: ^6.0.5
   url_launcher: ^6.1.7
   #開啟email phone url...
   logger: ^1.1.0
   #顯示Log
   sprintf: ^7.0.0
-  flutter_local_notifications: ^12.0.4
+  flutter_local_notifications: ^12.0.4 # restricted by alice 0.3.x
   #通知欄  需修改android原始碼
   rxdart: ^0.27.7
   #通知欄有使用到
-  video_player: ^2.4.9
+  video_player: ^2.4.10
   chewie: ^1.3.6
   after_init: ^0.1.2
   android_intent: ^2.0.2
   device_info: ^2.0.3
   html_unescape: ^2.0.0
   #處理HTML特殊字
-  local_auth: ^2.1.2
+  local_auth: ^2.1.3
   #驗證身分指紋
   version: ^3.0.2
   #版本比較
@@ -67,7 +67,7 @@ dependencies:
   clipboard: ^0.1.3
   #剪貼簿
   #----------WebView----------#
-  flutter_inappwebview: ^5.7.2+2
+  flutter_inappwebview: ^5.7.2+3
   flutter_web_browser:
     git:
       url: git@github.com:NEO-TAT/flutter_web_browser.git
@@ -84,7 +84,6 @@ dependencies:
   back_button_interceptor: ^6.0.2
   #攔截返回鍵訊息
   dart_big5: ^0.0.5
-  intl: ^0.17.0
 
   #DateTime to String
   package_info: ^2.0.2
@@ -108,13 +107,13 @@ dependencies:
   #用url顯示圖片
   auto_size_text: ^3.0.0
   #課表顯示有用到
-  table_calendar: 2.3.3 # force version
+  table_calendar: ^3.0.8 # force version
   #顯示行事曆
   flutter_xlider: ^3.4.0
   #語言切換用
   fluttertoast: ^8.1.2
   #Toast
-  awesome_dialog: ^2.2.1 # force version
+  awesome_dialog: ^3.0.2 # force version
   #顯示Error時用到
   flutter_slidable: ^2.0.0
   #email使用可左右滑抽屜
@@ -127,12 +126,12 @@ dependencies:
 
   # Firebase
   firebase_core: ^2.4.0
-  firebase_analytics: ^10.0.7
-  firebase_crashlytics: ^3.0.7
-  firebase_remote_config: ^3.0.7
-  firebase_messaging: ^14.1.4
-  cloud_firestore: ^4.2.0
-  firebase_auth: ^4.2.0
+  firebase_analytics: ^10.0.8
+  firebase_crashlytics: ^3.0.8
+  firebase_remote_config: ^3.0.8
+  firebase_messaging: ^14.2.0
+  cloud_firestore: ^4.3.0
+  firebase_auth: ^4.2.3
 
   http_parser: ^4.0.2
 
@@ -141,13 +140,16 @@ dependencies:
 
   weekday_selector: ^1.1.0
 
+dependency_overrides:
+  intl: ^0.18.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_launcher_icons: ^0.11.0
   flutter_native_splash: ^2.2.16
   #---------json----------#
-  build_runner: ^2.3.2
+  build_runner: ^2.3.3
   json_serializable: ^6.5.4
   flutter_lints: ^2.0.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
       url: git@github.com:NTUT-NPC/TAT-Core.git
       ref: main
 
-  path: 1.8.2 # restricted by flutter sdk.
+  path: ^1.8.2 # restricted by flutter sdk.
   path_provider: ^2.0.11
   provider: ^6.0.5
   url_launcher: ^6.1.7
@@ -87,13 +87,13 @@ dependencies:
   email_validator: ^2.1.17
   weekday_selector: ^1.1.0
 
-  firebase_core: ^2.4.0
-  firebase_analytics: ^10.0.8
-  firebase_crashlytics: ^3.0.8
-  firebase_remote_config: ^3.0.8
-  firebase_messaging: ^14.2.0
-  cloud_firestore: ^4.3.0
-  firebase_auth: ^4.2.3
+  firebase_core: ^2.4.1
+  firebase_analytics: ^10.1.0
+  firebase_crashlytics: ^3.0.9
+  firebase_remote_config: ^3.0.9
+  firebase_messaging: ^14.2.1
+  cloud_firestore: ^4.3.1
+  firebase_auth: ^4.2.4
 
 dependency_overrides:
   intl: ^0.18.0


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
Upgrade all dependencies and flutter sdk version to `3.3.10`.
The Android Kotlin version has upgraded to `1.8.0`.

There are three breaking changes:
- Awsome Dialog
  The dependency version has upgraded to v3, which deprecated the origin `DialogTyle` values.
  These update changes has addressed here: [3a0d35a](https://github.com/NEO-TAT/tat_flutter/pull/154/commits/3a0d35a6ab76d6dd1b4a526ae9ef97de773bd881).
- Alice
  Since the `alice` package on [`pub.dev`](https://pub.dev/packages/alice) depends on lots of its sub-packages which makes us hard to maintain TAT's dependency versions, we have migrated it to the [`alice_lightweight`](https://pub.dev/packages/alice_lightweight) package.
- Table Calendar
  Through the `table_calendar` package version has been upgraded to v3, we rebuilt the whole calendar page.
  First, a new `CalendarController`, which extends `GetXController`, has been created. We moved all non-UI layer functions and variables into this controller, and wrapped the calendar and calendar event list view widget by `GetBuilder` for receiving state updates from the controller.
  Then, we introduced a cache mechanism for the calendar data, which makes it not needed to re-fetch data while it has already exist.
  Additionally, the calendar style has also been refactored. You may found the event marker style changed, and the ripple effect of event ListTile has been fixed that it will not overflow of its container now.

In addition, the comments in the `pubspec.yml` file has been removed now, since they didn't express any useful meanings and make the file looks so messy.

> **Note**
> Includes some null safety migrations.

## How to Verify? <!-- btsbot.attachSection(<<##) -->

- Calendar page
1. open calendar page, check if it shows today's event (if provided)
2. switch to different day in the same month, see if the event can be shown properly, and the calendar's selected day changes to that day.
3. swipe to next month (and previous month), see if it can fetches the data and show them (the marker) on the calendar right away.
4. repeat step 2 but now in step 3's month.
5. change the calendar format to `week`, `two week`
6. enable English UI and see if there are any strange things. 

- Debug page (Alice)
1. Do something that needs to fetch data from BE, such as `ischool page`.
2. go to dev page. (contact @Xanonymous-GitHub If you don't know where it is)
3. go to `Dio Log` page
4. click on each log, see if any error occurrs.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->
<img width="50%" alt="截圖 2022-12-30 上午6 30 31" src="https://user-images.githubusercontent.com/47718989/210018503-1ea2095a-07d2-4263-bc3a-54bc6298edc0.png"><img width="50%" alt="截圖 2022-12-30 上午6 30 13" src="https://user-images.githubusercontent.com/47718989/210018520-4eafa2c8-2627-47b5-884f-86a9c7af3ad3.png">

