### PR TITLE
Fix calculation result page background color

### DIFF
--- a/lib/generated/intl/messages_all.dart
+++ b/lib/generated/intl/messages_all.dart
@@ -11,6 +11,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
@@ -20,8 +21,8 @@ import 'messages_zh_TW.dart' as messages_zh_tw;
 
 typedef LibraryLoader = Future<dynamic> Function();
 Map<String, LibraryLoader> _deferredLibraries = {
-  'en': () => Future.value(null),
-  'zh_TW': () => Future.value(null),
+  'en': () => SynchronousFuture(null),
+  'zh_TW': () => SynchronousFuture(null),
 };
 
 MessageLookupByLibrary? _findExact(String localeName) {
@@ -36,17 +37,17 @@ MessageLookupByLibrary? _findExact(String localeName) {
 }
 
 /// User programs should call this before using [localeName] for messages.
-Future<bool> initializeMessages(String localeName) async {
+Future<bool> initializeMessages(String localeName) {
   var availableLocale =
       Intl.verifiedLocale(localeName, (locale) => _deferredLibraries[locale] != null, onFailure: (_) => null);
   if (availableLocale == null) {
-    return Future.value(false);
+    return SynchronousFuture(false);
   }
   var lib = _deferredLibraries[availableLocale];
-  await (lib == null ? Future.value(false) : lib());
+  lib == null ? SynchronousFuture(false) : lib();
   initializeInternalMessageLookup(() => CompositeMessageLookup());
   messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
-  return Future.value(true);
+  return SynchronousFuture(true);
 }
 
 bool _messagesExistFor(String locale) {

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -271,7 +271,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "sure": MessageLookupByLibrary.simpleMessage("Sure"),
         "syllabus": MessageLookupByLibrary.simpleMessage("Syllabus"),
         "takeCore": MessageLookupByLibrary.simpleMessage("Take core"),
-        "takeForeignDepartmentCredits": MessageLookupByLibrary.simpleMessage("Foreign Department Credits"),
+        "takeForeignDepartmentCredits": MessageLookupByLibrary.simpleMessage("Foreign Dep Credits"),
         "takeForeignDepartmentCreditsLimit": MessageLookupByLibrary.simpleMessage("Credit limit"),
         "takeSelect": MessageLookupByLibrary.simpleMessage("Take select"),
         "time": MessageLookupByLibrary.simpleMessage("Time"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2038,10 +2038,10 @@ class S {
     );
   }
 
-  /// `Foreign Department Credits`
+  /// `Foreign Dep Credits`
   String get takeForeignDepartmentCredits {
     return Intl.message(
-      'Foreign Department Credits',
+      'Foreign Dep Credits',
       name: 'takeForeignDepartmentCredits',
       desc: '',
       args: [],

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -199,7 +199,7 @@
   "generalLessonSummary": "General lesson summary",
   "takeCore": "Take core",
   "takeSelect": "Take select",
-  "takeForeignDepartmentCredits": "Foreign Department Credits",
+  "takeForeignDepartmentCredits": "Foreign Dep Credits",
   "takeForeignDepartmentCreditsLimit": "Credit limit",
   "scoreCalculationWarning": "This calculation is for reference only. Actually, please focus on the school.",
   "resultsOfVariousSubjects": "Results of various subjects",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -192,7 +192,10 @@ class MyApp extends StatelessWidget {
             GlobalCupertinoLocalizations.delegate,
             GlobalMaterialLocalizations.delegate
           ],
-          builder: BotToastInit(),
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(textScaleFactor: 1),
+            child: BotToastInit().call(context, child) ?? const SizedBox.shrink(),
+          ),
           navigatorObservers: [BotToastNavigatorObserver(), AnalyticsUtils.observer],
           supportedLocales: S.delegate.supportedLocales,
           home: const MainScreen(),

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -76,9 +76,8 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
     int selectCredit = 0;
     int coreCredit = 0;
 
-    for (final key in generalLesson.keys) {
-      // FIXME: remove `!`.
-      for (final course in generalLesson[key]!) {
+    for (final courseScoreInfoList in generalLesson.values) {
+      for (final course in courseScoreInfoList) {
         if (course.isCoreGeneralLesson) {
           coreCredit += course.credit.toInt();
         } else {
@@ -113,9 +112,8 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
     final List<Widget> widgetList = [];
     int otherDepartmentCredit = 0;
 
-    for (final key in generalLesson.keys) {
-      // FIXME: remove `!`.
-      for (final course in generalLesson[key]!) {
+    for (final courseScoreInfoList in generalLesson.values) {
+      for (final course in courseScoreInfoList) {
         otherDepartmentCredit += course.credit.toInt();
         final courseItemWidget = _buildOneLineCourse(course.name, course.openClass);
         widgetList.add(courseItemWidget);

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -106,7 +106,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
     final department = LocalStorage.instance.getGraduationInformation().selectDepartment.substring(0, 2);
     final otherDepartmentMaxCredit = courseScoreCredit.graduationInformation.outerDepartmentMaxCredit;
 
-    final Map<String, List<CourseScoreInfoJson>> generalLesson = courseScoreCredit.getOtherDepartmentCourse(department);
+    final generalLesson = courseScoreCredit.getOtherDepartmentCourse(department);
     final List<Widget> widgetList = [];
     int otherDepartmentCredit = 0;
 

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -258,17 +258,12 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
               isScrollable: true,
               tabs: tabLabelList,
               onTap: (int index) {
-                _currentTabIndex = index;
-                setState(() {});
+                setState(() => _currentTabIndex = index);
               },
             ),
           ),
           body: SingleChildScrollView(
-            child: Column(
-              children: <Widget>[
-                if (!_isLoading) (tabChildList.isNotEmpty) ? tabChildList[_currentTabIndex] : const SizedBox.shrink(),
-              ],
-            ),
+            child: _isLoading ? const SizedBox.shrink() : tabChildList[_currentTabIndex],
           ),
         ),
       );

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -43,7 +43,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
   final List<Widget> tabChildList = [];
 
   int _currentTabIndex = 0;
-  bool isLoading = true;
+  bool _isLoading = true;
 
   Widget get _summaryTile {
     final titleWidget = _buildTile(sprintf("%s %d/%d", [
@@ -143,18 +143,14 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
       _addScoreRankTask();
     } else {
       _buildTabBar();
-      setState(() {
-        isLoading = false;
-      });
+      setState(() => _isLoading = false);
     }
   }
 
   void _addScoreRankTask() async {
     courseScoreList.clear();
 
-    setState(() {
-      isLoading = true;
-    });
+    setState(() => _isLoading = true);
 
     final taskFlow = TaskFlow();
     final scoreTask = ScoreRankTask();
@@ -208,9 +204,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
     }
 
     _buildTabBar();
-    setState(() {
-      isLoading = false;
-    });
+    setState(() => _isLoading = false);
   }
 
   void _onSelectFinish(GraduationInformationJson? value) {
@@ -272,7 +266,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
           body: SingleChildScrollView(
             child: Column(
               children: <Widget>[
-                if (!isLoading) (tabChildList.isNotEmpty) ? tabChildList[_currentTabIndex] : const SizedBox.shrink(),
+                if (!_isLoading) (tabChildList.isNotEmpty) ? tabChildList[_currentTabIndex] : const SizedBox.shrink(),
               ],
             ),
           ),

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -371,17 +371,16 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
       ),
       onTap: () {
         final result = courseScoreCredit.getCourseByType(type);
-        final List<String> courseInfo = [];
+        final List<String> courseInfoList = [];
 
-        for (final key in result.keys.toList()) {
-          courseInfo.add(key);
-          // FIXME: remove `!`.
-          for (final course in result[key]!) {
-            courseInfo.add(sprintf("     %s", [course.name]));
+        for (final courseScoreInfoEntry in result.entries) {
+          courseInfoList.add(courseScoreInfoEntry.key);
+          for (final course in courseScoreInfoEntry.value) {
+            courseInfoList.add(sprintf("     %s", [course.name]));
           }
         }
 
-        if (courseInfo.isNotEmpty) {
+        if (courseInfoList.isNotEmpty) {
           Get.dialog(
             AlertDialog(
               title: Text(R.current.creditInfo),
@@ -390,11 +389,11 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
                 child: ListView.builder(
                   shrinkWrap: true,
                   padding: const EdgeInsets.all(8),
-                  itemCount: courseInfo.length,
+                  itemCount: courseInfoList.length,
                   itemBuilder: (_, index) {
                     return SizedBox(
                       height: 35,
-                      child: Text(courseInfo[index]),
+                      child: Text(courseInfoList[index]),
                     );
                   },
                 ),

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -252,32 +252,24 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
         ),
       );
 
-  Widget _buildTile(String title) => Padding(
-        padding: const EdgeInsets.only(top: 10, bottom: 10),
-        child: Material(
-          child: Ink(
-            decoration: BoxDecoration(
-              borderRadius: const BorderRadius.all(Radius.circular(15.0)),
-              border: Border.all(
-                width: 2,
-                color: context.read<AppProvider>().theme.colorScheme.tertiary,
-              ),
-            ),
-            child: InkWell(
-              borderRadius: BorderRadius.circular(25.0),
-              child: Container(
-                alignment: const Alignment(0, 0),
-                height: 50,
-                width: 300,
-                child: Text(
-                  title,
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ),
-          ),
+  Widget _buildTile(String title) => Container(
+      height: 50,
+      width: 300,
+      margin: const EdgeInsets.symmetric(vertical: 10),
+      decoration: BoxDecoration(
+        borderRadius: const BorderRadius.all(Radius.circular(15.0)),
+        border: Border.all(
+          width: 2,
+          color: context.read<AppProvider>().theme.colorScheme.tertiary,
         ),
-      );
+      ),
+      child: Center(
+        child: Text(
+          title,
+          textAlign: TextAlign.center
+        ),
+      ),
+    );
 
   Widget _buildSummary() {
     final List<Widget> widgetList = [];

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -304,6 +304,72 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
     );
   }
 
+  Widget _buildGeneralLessonItem() {
+    final generalLesson = courseScoreCredit.getGeneralLesson();
+    final List<Widget> widgetList = [];
+    int selectCredit = 0;
+    int coreCredit = 0;
+
+    for (final key in generalLesson.keys) {
+      // FIXME: remove `!`.
+      for (final course in generalLesson[key]!) {
+        if (course.isCoreGeneralLesson) {
+          coreCredit += course.credit.toInt();
+        } else {
+          selectCredit += course.credit.toInt();
+        }
+
+        final courseItemWidget = _buildOneLineCourse(course.name, course.openClass);
+        widgetList.add(courseItemWidget);
+      }
+    }
+
+    final titleWidget = _buildTile(sprintf("%s \n %s:%d %s:%d", [
+      R.current.generalLessonSummary,
+      R.current.takeCore,
+      coreCredit,
+      R.current.takeSelect,
+      selectCredit,
+    ]));
+
+    return AppExpansionTile(
+      title: titleWidget,
+      initiallyExpanded: appExpansionInitiallyExpanded,
+      children: widgetList,
+    );
+  }
+
+  Widget _buildOtherDepartmentItem() {
+    final department = LocalStorage.instance.getGraduationInformation().selectDepartment.substring(0, 2);
+    final otherDepartmentMaxCredit = courseScoreCredit.graduationInformation.outerDepartmentMaxCredit;
+
+    Map<String, List<CourseScoreInfoJson>> generalLesson = courseScoreCredit.getOtherDepartmentCourse(department);
+    final List<Widget> widgetList = [];
+    int otherDepartmentCredit = 0;
+
+    for (final key in generalLesson.keys) {
+      // FIXME: remove `!`.
+      for (final course in generalLesson[key]!) {
+        otherDepartmentCredit += course.credit.toInt();
+        final courseItemWidget = _buildOneLineCourse(course.name, course.openClass);
+        widgetList.add(courseItemWidget);
+      }
+    }
+
+    final titleWidget = _buildTile(sprintf("%s: %d  %s: %d", [
+      R.current.takeForeignDepartmentCredits,
+      otherDepartmentCredit,
+      R.current.takeForeignDepartmentCreditsLimit,
+      otherDepartmentMaxCredit
+    ]));
+
+    return AppExpansionTile(
+      title: titleWidget,
+      initiallyExpanded: appExpansionInitiallyExpanded,
+      children: widgetList,
+    );
+  }
+
   Widget _buildType(String type, String title) {
     final nowCredit = courseScoreCredit.getCreditByType(type);
     final minCredit = courseScoreCredit.graduationInformation.courseTypeMinCredit[type];
@@ -382,72 +448,6 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
           ],
         ),
       );
-
-  Widget _buildGeneralLessonItem() {
-    final generalLesson = courseScoreCredit.getGeneralLesson();
-    final List<Widget> widgetList = [];
-    int selectCredit = 0;
-    int coreCredit = 0;
-
-    for (final key in generalLesson.keys) {
-      // FIXME: remove `!`.
-      for (final course in generalLesson[key]!) {
-        if (course.isCoreGeneralLesson) {
-          coreCredit += course.credit.toInt();
-        } else {
-          selectCredit += course.credit.toInt();
-        }
-
-        final courseItemWidget = _buildOneLineCourse(course.name, course.openClass);
-        widgetList.add(courseItemWidget);
-      }
-    }
-
-    final titleWidget = _buildTile(sprintf("%s \n %s:%d %s:%d", [
-      R.current.generalLessonSummary,
-      R.current.takeCore,
-      coreCredit,
-      R.current.takeSelect,
-      selectCredit,
-    ]));
-
-    return AppExpansionTile(
-      title: titleWidget,
-      initiallyExpanded: appExpansionInitiallyExpanded,
-      children: widgetList,
-    );
-  }
-
-  Widget _buildOtherDepartmentItem() {
-    final department = LocalStorage.instance.getGraduationInformation().selectDepartment.substring(0, 2);
-    final otherDepartmentMaxCredit = courseScoreCredit.graduationInformation.outerDepartmentMaxCredit;
-
-    Map<String, List<CourseScoreInfoJson>> generalLesson = courseScoreCredit.getOtherDepartmentCourse(department);
-    final List<Widget> widgetList = [];
-    int otherDepartmentCredit = 0;
-
-    for (final key in generalLesson.keys) {
-      // FIXME: remove `!`.
-      for (final course in generalLesson[key]!) {
-        otherDepartmentCredit += course.credit.toInt();
-        final courseItemWidget = _buildOneLineCourse(course.name, course.openClass);
-        widgetList.add(courseItemWidget);
-      }
-    }
-
-    final titleWidget = _buildTile(sprintf("%s: %d  %s: %d", [
-      R.current.takeForeignDepartmentCredits,
-      otherDepartmentCredit,
-      R.current.takeForeignDepartmentCreditsLimit,
-      otherDepartmentMaxCredit
-    ]));
-
-    return AppExpansionTile(
-      title: titleWidget,
-      initiallyExpanded: appExpansionInitiallyExpanded,
-      children: widgetList,
-    );
-  }
 
   Widget _buildSemesterScores(SemesterCourseScoreJson courseScore) => Padding(
         padding: const EdgeInsets.all(24.0),

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -243,33 +243,23 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
   }
 
   Widget _buildTabLabel(String title) => Padding(
-        padding: const EdgeInsets.only(
-          left: 12,
-          right: 12,
-        ),
-        child: Tab(
-          text: title,
-        ),
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Tab(text: title),
       );
 
   Widget _buildTile(String title) => Container(
-      height: 50,
-      width: 300,
-      margin: const EdgeInsets.symmetric(vertical: 10),
-      decoration: BoxDecoration(
-        borderRadius: const BorderRadius.all(Radius.circular(15.0)),
-        border: Border.all(
-          width: 2,
-          color: context.read<AppProvider>().theme.colorScheme.tertiary,
+        height: 50,
+        width: 300,
+        margin: const EdgeInsets.symmetric(vertical: 10),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            width: 2,
+            color: context.read<AppProvider>().theme.colorScheme.tertiary,
+          ),
         ),
-      ),
-      child: Center(
-        child: Text(
-          title,
-          textAlign: TextAlign.center
-        ),
-      ),
-    );
+        child: Center(child: Text(title, textAlign: TextAlign.center)),
+      );
 
   Widget _buildSummary() {
     final List<Widget> widgetList = [];

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -87,7 +87,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
       }
     }
 
-    final titleWidget = _buildTile(sprintf("%s \n %s:%d %s:%d", [
+    final titleWidget = _buildTile(sprintf("%s\n%s: %d %s: %d", [
       R.current.generalLessonSummary,
       R.current.takeCore,
       coreCredit,
@@ -106,7 +106,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
     final department = LocalStorage.instance.getGraduationInformation().selectDepartment.substring(0, 2);
     final otherDepartmentMaxCredit = courseScoreCredit.graduationInformation.outerDepartmentMaxCredit;
 
-    Map<String, List<CourseScoreInfoJson>> generalLesson = courseScoreCredit.getOtherDepartmentCourse(department);
+    final Map<String, List<CourseScoreInfoJson>> generalLesson = courseScoreCredit.getOtherDepartmentCourse(department);
     final List<Widget> widgetList = [];
     int otherDepartmentCredit = 0;
 
@@ -335,7 +335,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
       );
 
   Widget _buildTile(String title) => Container(
-        height: 50,
+        height: 60,
         width: 300,
         margin: const EdgeInsets.symmetric(vertical: 10),
         decoration: BoxDecoration(
@@ -345,7 +345,9 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
             color: context.read<AppProvider>().theme.colorScheme.tertiary,
           ),
         ),
-        child: Center(child: Text(title, textAlign: TextAlign.center)),
+        child: Center(
+          child: Text(title, textAlign: TextAlign.center),
+        ),
       );
 
   Widget _buildType(String type, String title) {

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -46,25 +46,23 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
   bool isLoading = true;
 
   Widget get _summaryTile {
-    final List<Widget> widgetList = [];
-    final graduationInformation = courseScoreCredit.graduationInformation;
-
-    final widget = _buildTile(sprintf("%s %d/%d", [
+    final titleWidget = _buildTile(sprintf("%s %d/%d", [
       R.current.creditSummary,
       courseScoreCredit.getTotalCourseCredit(),
-      graduationInformation.lowCredit,
+      courseScoreCredit.graduationInformation.lowCredit,
     ]));
 
-    widgetList
-      ..add(_buildType(constCourseType[0], R.current.compulsoryCompulsory))
-      ..add(_buildType(constCourseType[1], R.current.revisedCommonCompulsory))
-      ..add(_buildType(constCourseType[2], R.current.jointElective))
-      ..add(_buildType(constCourseType[3], R.current.compulsoryProfessional))
-      ..add(_buildType(constCourseType[4], R.current.compulsoryMajorRevision))
-      ..add(_buildType(constCourseType[5], R.current.professionalElectives));
+    final widgetList = [
+      _buildType(constCourseType[0], R.current.compulsoryCompulsory),
+      _buildType(constCourseType[1], R.current.revisedCommonCompulsory),
+      _buildType(constCourseType[2], R.current.jointElective),
+      _buildType(constCourseType[3], R.current.compulsoryProfessional),
+      _buildType(constCourseType[4], R.current.compulsoryMajorRevision),
+      _buildType(constCourseType[5], R.current.professionalElectives),
+    ];
 
     return AppExpansionTile(
-      title: widget,
+      title: titleWidget,
       initiallyExpanded: appExpansionInitiallyExpanded,
       children: widgetList,
     );


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->

This pull request mainly fixes the ripple effect issue in calculation result page, which is described in [this issue](https://github.com/NEO-TAT/tat_flutter/issues/126)

Also did some refactoring and solved some `FIXME`s.

## How to Verify? <!-- btsbot.attachSection(<<##) -->

Check the following features:
1. Go to calculation page and long press the `ExpansionTile`s to see if ripple effect covers the entire widget (outside the border).
2. Check if the content in the expansion tile shows as is.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->

