### PR TITLE
Fix calendar event card scroll overflow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,7 +181,6 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Consumer<AppProvider>(builder: (context, appProvider, child) {
-        appProvider.navigatorKey = Get.key;
         return GetMaterialApp(
           title: AppConfig.appName,
           theme: appProvider.theme,

--- a/lib/src/controllers/calendar_controller.dart
+++ b/lib/src/controllers/calendar_controller.dart
@@ -109,6 +109,10 @@ class CalendarController extends GetxController {
 
       for (final nonAddedSchoolEvent in schoolEvents) {
         final eventTime = nonAddedSchoolEvent.startTime.toLocal();
+        if (eventTime.isBefore(firstDayOfTargetMonth) || eventTime.isAfter(lastDayOfTargetMonth)) {
+          continue;
+        }
+
         knownSchoolEvents.update(
           eventTime,
           (addedEvents) => [...addedEvents, nonAddedSchoolEvent],

--- a/lib/src/providers/app_provider.dart
+++ b/lib/src/providers/app_provider.dart
@@ -4,49 +4,35 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_app/src/config/app_colors.dart';
 import 'package:flutter_app/src/config/app_themes.dart';
-import 'package:flutter_app/ui/other/my_toast.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AppProvider extends ChangeNotifier {
-  static AppProvider instance = AppProvider();
+  static final AppProvider instance = AppProvider._();
 
-  factory AppProvider() = AppProvider._;
+  factory AppProvider() => instance;
 
   AppProvider._() {
     checkTheme();
   }
 
-  ThemeData theme = Get.isDarkMode ? AppThemes.darkTheme : AppThemes.lightTheme;
-  Key key = UniqueKey();
-  GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+  ThemeData get theme => (() => _theme)();
+  ThemeData _theme = Get.isDarkMode ? AppThemes.darkTheme : AppThemes.lightTheme;
+  final Key key = UniqueKey();
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
-  void setKey(value) {
-    key = value;
-    notifyListeners();
-  }
-
-  void setNavigatorKey(value) {
-    navigatorKey = value;
-    notifyListeners();
-  }
-
-  void setTheme(value, c) {
-    theme = value;
+  void setTheme(ThemeData value, String colorName) {
+    _theme = value;
     SharedPreferences.getInstance().then((prefs) {
-      prefs.setString("theme", c).then((val) {
+      prefs.setString("theme", colorName).then((val) {
         SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: SystemUiOverlay.values);
         SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-          statusBarColor: c == "dark" ? AppColors.darkPrimary : AppColors.mainColor,
-          statusBarIconBrightness: c == "dark" ? Brightness.light : Brightness.dark,
+          statusBarColor: colorName == "dark" ? AppColors.darkPrimary : AppColors.mainColor,
+          statusBarIconBrightness: colorName == "dark" ? Brightness.light : Brightness.dark,
         ));
       });
     });
     notifyListeners();
-  }
-
-  ThemeData getTheme(value) {
-    return theme;
   }
 
   Future<ThemeData> checkTheme() async {
@@ -63,10 +49,5 @@ class AppProvider extends ChangeNotifier {
     }
 
     return t;
-  }
-
-  void showToast(value) {
-    MyToast.show(value);
-    notifyListeners();
   }
 }

--- a/lib/src/task/dialog_task.dart
+++ b/lib/src/task/dialog_task.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: import_of_legacy_library_into_null_safe
 
+import 'package:awesome_dialog/awesome_dialog.dart';
 import 'package:connectivity/connectivity.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/ui/other/msg_dialog.dart';
@@ -32,6 +33,7 @@ class DialogTask<T> extends Task<T> {
   Future<TaskStatus> onError(String message) async {
     final parameter = MsgDialogParameter(
       desc: message,
+      dialogType: DialogType.warning,
     );
     return await onErrorParameter(parameter);
   }

--- a/lib/ui/pages/calendar/calendar_page.dart
+++ b/lib/ui/pages/calendar/calendar_page.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/src/controllers/calendar_controller.dart';
 import 'package:flutter_app/src/model/ntut/ntut_calendar_json.dart';
-import 'package:flutter_app/src/providers/app_provider.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/ui/pages/calendar/calendar_detail_dialog.dart';
 import 'package:get/get.dart';
@@ -12,8 +11,8 @@ import 'package:table_calendar/table_calendar.dart';
 class CalendarPage extends StatelessWidget {
   const CalendarPage({super.key});
 
-  Widget _buildEventList(List<NTUTCalendarJson> selectedEvents) {
-    final eventBorderColor = AppProvider.instance.theme.colorScheme.onBackground;
+  Widget _buildEventList(BuildContext context, List<NTUTCalendarJson> selectedEvents) {
+    final eventBorderColor = Theme.of(context).colorScheme.onBackground;
     return ListView.builder(
       itemCount: selectedEvents.length,
       itemBuilder: (context, index) {
@@ -86,7 +85,7 @@ class CalendarPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) => FutureBuilder(
         future: CalendarController.to.findFirstEventsFromToday(),
-        builder: (_, __) => Scaffold(
+        builder: (context, __) => Scaffold(
           appBar: AppBar(
             title: Text(R.current.calendar),
           ),
@@ -97,7 +96,7 @@ class CalendarPage extends StatelessWidget {
                 _buildTableCalendar(controller),
                 const SizedBox(height: 16.0),
                 Expanded(
-                  child: _buildEventList(controller.selectedEventsRx),
+                  child: _buildEventList(context, controller.selectedEventsRx),
                 ),
               ],
             ),

--- a/lib/ui/pages/calendar/calendar_page.dart
+++ b/lib/ui/pages/calendar/calendar_page.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/src/controllers/calendar_controller.dart';
 import 'package:flutter_app/src/model/ntut/ntut_calendar_json.dart';
+import 'package:flutter_app/src/providers/app_provider.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/ui/pages/calendar/calendar_detail_dialog.dart';
 import 'package:get/get.dart';
@@ -11,31 +12,31 @@ import 'package:table_calendar/table_calendar.dart';
 class CalendarPage extends StatelessWidget {
   const CalendarPage({super.key});
 
-  Widget _buildEventList(List<NTUTCalendarJson> selectedEvents) => ListView.builder(
-        itemCount: selectedEvents.length,
-        itemBuilder: (context, index) {
-          final event = selectedEvents[index];
-          return Padding(
-            padding: const EdgeInsets.all(4.0),
-            child: InkWell(
-              customBorder: RoundedRectangleBorder(
+  Widget _buildEventList(List<NTUTCalendarJson> selectedEvents) {
+    final eventBorderColor = AppProvider.instance.theme.colorScheme.onBackground;
+    return ListView.builder(
+      itemCount: selectedEvents.length,
+      itemBuilder: (context, index) {
+        final event = selectedEvents[index];
+        return Padding(
+          padding: const EdgeInsets.all(4.0),
+          child: Card(
+            child: ListTile(
+              title: Text(event.calTitle),
+              shape: RoundedRectangleBorder(
+                side: BorderSide(color: eventBorderColor),
                 borderRadius: BorderRadius.circular(12),
               ),
-              child: ListTile(
-                title: Text(event.calTitle),
-                shape: RoundedRectangleBorder(
-                  side: const BorderSide(color: Colors.grey),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                onTap: () => Get.dialog(
-                  CalendarDetailDialog(calendarDetail: event),
-                  barrierDismissible: true,
-                ),
+              onTap: () => Get.dialog(
+                CalendarDetailDialog(calendarDetail: event),
+                barrierDismissible: true,
               ),
             ),
-          );
-        },
-      );
+          ),
+        );
+      },
+    );
+  }
 
   Widget _buildTableCalendar(CalendarController controller) => TableCalendar(
         focusedDay: controller.focusDayRx.value,

--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -18,7 +18,6 @@ import 'package:flutter_app/ui/pages/coursetable/course_table_page.dart';
 import 'package:flutter_app/ui/pages/notification/notification_page.dart';
 import 'package:flutter_app/ui/pages/other/other_page.dart';
 import 'package:flutter_app/ui/pages/score/score_page.dart';
-import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 
 class MainScreen extends StatefulWidget {

--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -106,7 +106,6 @@ class _MainScreenState extends State<MainScreen> with RouteAware {
   @override
   Widget build(BuildContext context) => Consumer<AppProvider>(
         builder: (context, appProvider, child) {
-          appProvider.navigatorKey = Get.key;
           return WillPopScope(
             onWillPop: _onWillPop,
             child: Scaffold(


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
In #154, the new-refactored calendar seems still has some problems.
- The event tile of calendar may be able to scroll overflow, which overlapped the calendar section.
- The event of any day maybe duplicate because the school server can't respond an accurate range of events. For example, if the given event range is 01/01 ~ 01/31, the server may respond events between 12/xx ~ 02/xx (not constantly).

So in this PR, 
- make the event card disappeared when scroll over. (by using the `Card` widget)
- we tried to prevent the event not in expected scope been added into the list while creating calendar.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
For the UI problem (prefer validating in iOS):
1. go to calendar page
2. choose a day which contains some events and click it
3. scroll the event list (toward top), check if the overflowed event cards are not overlapped the calendar section.

For the event duplicate problem:
1. go to calendar page
4. see 2023/02/20 events, there should be four events.
5. swipe to 2023/03's calendar, after it loaded, swipe back to 2023/02
6. check if 2023/02/20 still has four events.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->
<img src="https://user-images.githubusercontent.com/47718989/219869439-ed350d06-f4b6-4655-9a45-69874dde3a92.jpg" height="200">

