### PR TITLE
Fix circular progress indicator UI

### DIFF
--- a/lib/ui/other/custom_progress_dialog.dart
+++ b/lib/ui/other/custom_progress_dialog.dart
@@ -1,20 +1,18 @@
-// TODO: remove sdk version selector after migrating to null-safety.
-// @dart=2.10
 import 'package:flutter/material.dart';
 
 class CustomProgressDialog extends StatelessWidget {
   const CustomProgressDialog({
-    Key key,
+    super.key,
     this.child,
     this.insetAnimationDuration = const Duration(milliseconds: 100),
     this.insetAnimationCurve = Curves.decelerate,
     this.shape,
-  }) : super(key: key);
+  });
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.child}
-  final Widget child;
+  final Widget? child;
 
   /// The duration of the animation to show when the system keyboard intrudes
   /// into the space that the dialog is placed in.
@@ -35,37 +33,33 @@ class CustomProgressDialog extends StatelessWidget {
   ///
   /// The default shape is a [RoundedRectangleBorder] with a radius of 2.0.
   /// {@endtemplate}
-  final ShapeBorder shape;
+  final ShapeBorder? shape;
 
-  Color _getColor(BuildContext context) {
-    return Theme.of(context).dialogBackgroundColor;
-  }
+  Color _getColor(BuildContext context) => Theme.of(context).dialogBackgroundColor;
 
   @override
-  Widget build(BuildContext context) {
-    return AnimatedPadding(
-      padding: MediaQuery.of(context).viewInsets + const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
-      duration: insetAnimationDuration,
-      curve: insetAnimationCurve,
-      child: MediaQuery.removeViewInsets(
-        removeLeft: true,
-        removeTop: true,
-        removeRight: true,
-        removeBottom: true,
-        context: context,
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(),
-            child: Material(
-              elevation: 24.0,
-              color: _getColor(context),
-              type: MaterialType.card,
-              borderRadius: const BorderRadius.all(Radius.circular(5)),
-              child: child,
+  Widget build(BuildContext context) => AnimatedPadding(
+        padding: MediaQuery.of(context).viewInsets + const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+        duration: insetAnimationDuration,
+        curve: insetAnimationCurve,
+        child: MediaQuery.removeViewInsets(
+          removeLeft: true,
+          removeTop: true,
+          removeRight: true,
+          removeBottom: true,
+          context: context,
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(),
+              child: Material(
+                elevation: 24.0,
+                color: _getColor(context),
+                type: MaterialType.card,
+                borderRadius: const BorderRadius.all(Radius.circular(5)),
+                child: child,
+              ),
             ),
           ),
         ),
-      ),
-    );
-  }
+      );
 }

--- a/lib/ui/other/my_progress_dialog.dart
+++ b/lib/ui/other/my_progress_dialog.dart
@@ -1,54 +1,41 @@
-// TODO: remove sdk version selector after migrating to null-safety.
-// @dart=2.10
-import 'dart:io';
-
 import 'package:bot_toast/bot_toast.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-import 'custom_progress_dialog.dart';
+import 'package:flutter_app/ui/other/custom_progress_dialog.dart';
 
 class MyProgressDialog {
-  static void showProgressDialogOld(BuildContext context, String message) async {}
-
-  static void progressDialog(String message) async {
-    BotToast.showCustomLoading(toastBuilder: (cancel) {
-      return CustomProgressDialog(
+  static void progressDialog(String? message) {
+    BotToast.showCustomLoading(
+      toastBuilder: (cancel) => CustomProgressDialog(
         child: Container(
-          decoration: const BoxDecoration(color: Colors.black, borderRadius: BorderRadius.all(Radius.circular(5))),
+          decoration: const BoxDecoration(
+            color: Colors.black,
+            borderRadius: BorderRadius.all(Radius.circular(5)),
+          ),
           padding: const EdgeInsets.all(20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Platform.isIOS
-                  ? const CupertinoActivityIndicator(
-                      radius: 15,
-                    )
-                  : const CircularProgressIndicator(),
-              message == null
-                  ? const Padding(
-                      padding: EdgeInsets.all(0),
-                    )
-                  : Padding(
-                      padding: const EdgeInsets.only(top: 10),
-                      child: Text(
-                        message,
-                        style: const TextStyle(color: Colors.white),
-                        textAlign: TextAlign.center,
+          child: FittedBox(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const CircularProgressIndicator(),
+                message == null
+                    ? const SizedBox.shrink()
+                    : Padding(
+                        padding: const EdgeInsets.only(top: 10),
+                        child: Text(
+                          message,
+                          style: const TextStyle(color: Colors.white),
+                          textAlign: TextAlign.center,
+                        ),
                       ),
-                    ),
-            ],
+              ],
+            ),
           ),
         ),
-      );
-    });
+      ),
+    );
   }
 
-  static Future<void> hideProgressDialog() async {
-    BotToast.cleanAll();
-  }
+  static void hideProgressDialog() => BotToast.cleanAll();
 
-  static Future<void> hideAllDialog() async {
-    BotToast.cleanAll();
-  }
+  static void hideAllDialog() => BotToast.cleanAll();
 }

--- a/lib/ui/other/my_progress_dialog.dart
+++ b/lib/ui/other/my_progress_dialog.dart
@@ -7,9 +7,9 @@ class MyProgressDialog {
     BotToast.showCustomLoading(
       toastBuilder: (cancel) => CustomProgressDialog(
         child: Container(
-          decoration: const BoxDecoration(
+          decoration: BoxDecoration(
             color: Colors.black,
-            borderRadius: BorderRadius.all(Radius.circular(5)),
+            borderRadius: BorderRadius.circular(5),
           ),
           padding: const EdgeInsets.all(20),
           child: FittedBox(
@@ -17,16 +17,15 @@ class MyProgressDialog {
               mainAxisSize: MainAxisSize.min,
               children: [
                 const CircularProgressIndicator(),
-                message == null
-                    ? const SizedBox.shrink()
-                    : Padding(
-                        padding: const EdgeInsets.only(top: 10),
-                        child: Text(
-                          message,
-                          style: const TextStyle(color: Colors.white),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
+                if (message != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 10),
+                    child: Text(
+                      message,
+                      style: const TextStyle(color: Colors.white),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
               ],
             ),
           ),

--- a/lib/ui/pages/coursetable/course_table_page.dart
+++ b/lib/ui/pages/coursetable/course_table_page.dart
@@ -359,14 +359,15 @@ class _CourseTablePageState extends State<CourseTablePage> {
         title: Text(R.current.titleCourse),
         actions: [
           (!isLoading && loadCourseNotice)
-              ? const Padding(
-                  padding: EdgeInsets.all(10),
+              ? Padding(
+                  padding: const EdgeInsets.all(10),
                   child: CircularProgressIndicator(
-                    backgroundColor: Colors.white,
+                    backgroundColor: Theme.of(context).colorScheme.background,
+                    color: Theme.of(context).colorScheme.tertiary,
                     strokeWidth: 4,
                   ),
                 )
-              : Container(),
+              : const SizedBox.shrink(),
           (!isLoading && LocalStorage.instance.getAccount() != courseTableData?.studentId)
               ? Padding(
                   padding: const EdgeInsets.only(


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
The circular progress indicator in the course table page's appbar seems not pretty enough.
and sometimes it will cause UI overflow exception but not been noticed.

So this PR tried to fix these problems.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
Go to course table page, and see the circular progress indicator's color
check if you like it.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->

<table>
<tr>
<td><img src="https://user-images.githubusercontent.com/47718989/219870995-09c894d0-b322-4709-b6ba-235378725c63.jpg"></td>
<td><img src="https://user-images.githubusercontent.com/47718989/219870999-b025d82a-1335-47b6-9dbd-4df9c0dc3063.jpg"></td>
</tr>
</table>

