### PR TITLE
Detect whether login session is valid and retry automatically

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,6 +73,7 @@ Future<void> main() async {
   final zMakeRollCallRepository = ZMakeRollCallRepository(apiService: zuvioApiService);
 
   final simpleLoginRepository = SimpleLoginRepository(apiService: schoolApiService);
+  final checkSessionRepository = CheckSessionRepository(apiService: schoolApiService);
 
   final zuvioLoginUseCase = ZLoginUseCase(zuvioLoginRepository);
   final zuvioGetCourseListUseCase = ZGetStudentCourseListUseCase(zStudentCourseListRepository);
@@ -114,6 +115,8 @@ Future<void> main() async {
     autoRollCallScheduleRepository,
   );
 
+  final checkSessionIsAliveUseCase = CheckSessionUseCase(checkSessionRepository);
+
   final zAuthController = ZAuthController(
     isLoginBtnEnabled: true,
     isInputBoxesEnabled: true,
@@ -150,6 +153,7 @@ Future<void> main() async {
   Get.put(simpleLoginUseCase);
   Get.put(cookieJar);
   Get.put(calendarController);
+  Get.put(checkSessionIsAliveUseCase);
 
   await LocalStorage.instance.init(httpClientInterceptors: apiInterceptors);
 

--- a/lib/src/task/ntut/ntut_task.dart
+++ b/lib/src/task/ntut/ntut_task.dart
@@ -10,7 +10,8 @@ import 'package:flutter_app/src/store/local_storage.dart';
 import 'package:flutter_app/src/task/task.dart';
 import 'package:flutter_app/ui/other/msg_dialog.dart';
 import 'package:flutter_app/ui/other/route_utils.dart';
-import 'package:tat_core/core/portal/domain/simple_login_result.dart';
+import 'package:get/get.dart';
+import 'package:tat_core/tat_core.dart';
 
 import '../dialog_task.dart';
 
@@ -33,8 +34,19 @@ class NTUTTask<T> extends DialogTask<T> {
       LocalStorage.instance.logout();
       RouteUtils.toLoginScreen();
       return TaskStatus.shouldGiveUp;
-    } else if (_isLogin) {
-      return TaskStatus.success;
+    }
+
+    if (_isLogin) {
+      // Strictly check if the current session is still alive.
+      // This is because the school's backend only allow one session at the same time.
+      // So if current session was expired or hijacked by other client, we should try to login again.
+
+      final checkSessionUseCase = Get.find<CheckSessionUseCase>();
+      final isCurrentSessionAlive = await checkSessionUseCase();
+
+      if (isCurrentSessionAlive) {
+        return TaskStatus.success;
+      }
     }
 
     try {

--- a/lib/src/task/ntut/ntut_task.dart
+++ b/lib/src/task/ntut/ntut_task.dart
@@ -42,7 +42,10 @@ class NTUTTask<T> extends DialogTask<T> {
       // So if current session was expired or hijacked by other client, we should try to login again.
 
       final checkSessionUseCase = Get.find<CheckSessionUseCase>();
+
+      super.onStart(R.current.loading);
       final isCurrentSessionAlive = await checkSessionUseCase();
+      super.onEnd();
 
       if (isCurrentSessionAlive) {
         return TaskStatus.success;

--- a/lib/src/task/task_flow.dart
+++ b/lib/src/task/task_flow.dart
@@ -48,15 +48,13 @@ class TaskFlow {
     }
     bool success = true;
     while (_queue.isNotEmpty) {
-      Task task = _queue.first;
-      TaskStatus status = await task.execute();
+      final task = _queue.first;
+      final status = await task.execute();
       switch (status) {
         case TaskStatus.success:
           _queue.removeAt(0);
           _completeTask.add(task);
-          if (callback != null) {
-            callback?.call(task);
-          }
+          callback?.call(task);
           break;
         case TaskStatus.shouldGiveUp:
           _failTask.addAll(_queue);


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
In this PR, we use the `CheckSessionUseCase` in the core package to help us detect where the current session is valid or not.

Sometimes, the client's session will be marked as invalid by server since another client has logged-in, too.
Or it expired by time.

So when we are trying to do other tasks like calendar, iplus, score ..., it will not be able to get an expected response (the step of using real service, 3rd step of ntut login described in core api service interface).
Hence, knowing whether we should start from the step 1, fetch initial JSESSION cookie, is necessary.

And this also solve #62 since it will auto retry.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
1. open TAT. this is phone A
2. use another phone, open TAT. this is phone B.
3. go to phone A, and go to calendar page (for `calendar_task`)
4. On phone A, check if it can show the calendar normally without showing any error dialog.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->

