### PR TITLE
Add autofill hints to login screen

### DIFF
--- a/lib/ui/screen/login_screen.dart
+++ b/lib/ui/screen/login_screen.dart
@@ -184,10 +184,8 @@ class _LoginScreenState extends State<LoginScreen> {
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(32),
                             ),
-                            textStyle: const TextStyle(
-                                color: AppColors.lightFontColor),
-                            padding: const EdgeInsets.symmetric(
-                                vertical: 12, horizontal: 16),
+                            textStyle: const TextStyle(color: AppColors.lightFontColor),
+                            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
                           ),
                           onPressed: () => _loginPress(context),
                           child: Text(
@@ -247,8 +245,7 @@ class _LoginScreenState extends State<LoginScreen> {
             width: double.infinity,
             height: MediaQuery.of(context).size.height * 0.4,
             decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                  colors: [Color(0x222196f3), Color(0x2203a9f4)]),
+              gradient: LinearGradient(colors: [Color(0x222196f3), Color(0x2203a9f4)]),
             ),
             child: Column(),
           ),
@@ -275,13 +272,11 @@ class WaveClipper1 extends CustomClipper<Path> {
 
     var firstEndPoint = Offset(size.width * 0.6, size.height - 29 - 50);
     var firstControlPoint = Offset(size.width * .25, size.height - 60 - 50);
-    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy,
-        firstEndPoint.dx, firstEndPoint.dy);
+    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy, firstEndPoint.dx, firstEndPoint.dy);
 
     var secondEndPoint = Offset(size.width, size.height - 60);
     var secondControlPoint = Offset(size.width * 0.84, size.height - 50);
-    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy,
-        secondEndPoint.dx, secondEndPoint.dy);
+    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy, secondEndPoint.dx, secondEndPoint.dy);
     path.lineTo(size.width, size.height);
     path.lineTo(size.width, 0);
     path.close();
@@ -302,13 +297,11 @@ class WaveClipper2 extends CustomClipper<Path> {
 
     var firstEndPoint = Offset(size.width * 0.6, size.height - 15 - 50);
     var firstControlPoint = Offset(size.width * .25, size.height - 60 - 50);
-    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy,
-        firstEndPoint.dx, firstEndPoint.dy);
+    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy, firstEndPoint.dx, firstEndPoint.dy);
 
     var secondEndPoint = Offset(size.width, size.height - 40);
     var secondControlPoint = Offset(size.width * 0.84, size.height - 30);
-    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy,
-        secondEndPoint.dx, secondEndPoint.dy);
+    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy, secondEndPoint.dx, secondEndPoint.dy);
     path.lineTo(size.width, size.height);
     path.lineTo(size.width, 0);
     path.close();
@@ -329,13 +322,11 @@ class WaveClipper3 extends CustomClipper<Path> {
 
     var firstEndPoint = Offset(size.width * .7, size.height - 40);
     var firstControlPoint = Offset(size.width * .25, size.height);
-    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy,
-        firstEndPoint.dx, firstEndPoint.dy);
+    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy, firstEndPoint.dx, firstEndPoint.dy);
 
     var secondEndPoint = Offset(size.width, size.height - 45);
     var secondControlPoint = Offset(size.width * 0.84, size.height - 50);
-    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy,
-        secondEndPoint.dx, secondEndPoint.dy);
+    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy, secondEndPoint.dx, secondEndPoint.dy);
     path.lineTo(size.width, size.height);
     path.lineTo(size.width, 0);
     path.close();

--- a/lib/ui/screen/login_screen.dart
+++ b/lib/ui/screen/login_screen.dart
@@ -92,7 +92,7 @@ class _LoginScreenState extends State<LoginScreen> {
                     children: <Widget>[
                       Material(
                         elevation: 2,
-                        borderRadius: const BorderRadius.all(Radius.circular(32)),
+                        borderRadius: BorderRadius.circular(32),
                         child: TextFormField(
                           controller: _accountControl,
                           cursorColor: Colors.blue[800],
@@ -103,7 +103,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             _accountFocus.unfocus();
                             FocusScope.of(context).requestFocus(_passwordFocus);
                           },
-                          validator: (value) => _validatorAccount(value),
+                          validator: _validatorAccount,
                           decoration: InputDecoration(
                             hintText: R.current.account,
                             errorStyle: const TextStyle(
@@ -118,9 +118,7 @@ class _LoginScreenState extends State<LoginScreen> {
                           ),
                         ),
                       ),
-                      const SizedBox(
-                        height: 4,
-                      ),
+                      const SizedBox(height: 4),
                       if (_accountErrorMessage.isNotEmpty)
                         Padding(
                           padding: const EdgeInsets.only(left: 16),
@@ -132,12 +130,10 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                           ),
                         ),
-                      const SizedBox(
-                        height: 20,
-                      ),
+                      const SizedBox(height: 20),
                       Material(
                         elevation: 2,
-                        borderRadius: const BorderRadius.all(Radius.circular(32)),
+                        borderRadius: BorderRadius.circular(32),
                         child: TextFormField(
                           controller: _passwordControl,
                           cursorColor: Colors.blue[800],
@@ -148,7 +144,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             _passwordFocus.unfocus();
                             TextInput.finishAutofillContext();
                           },
-                          validator: (value) => _validatorPassword(value),
+                          validator: _validatorPassword,
                           decoration: InputDecoration(
                             hintText: R.current.password,
                             errorStyle: const TextStyle(
@@ -167,9 +163,7 @@ class _LoginScreenState extends State<LoginScreen> {
                           ),
                         ),
                       ),
-                      const SizedBox(
-                        height: 4,
-                      ),
+                      const SizedBox(height: 4),
                       if (_passwordErrorMessage.isNotEmpty)
                         Padding(
                           padding: const EdgeInsets.only(left: 16),
@@ -181,26 +175,24 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                           ),
                         ),
-                      const SizedBox(
-                        height: 25,
-                      ),
+                      const SizedBox(height: 25),
                       Align(
                         alignment: Alignment.center,
                         child: TextButton(
                           style: TextButton.styleFrom(
                             foregroundColor: AppColors.mainColor,
                             shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(32.0),
+                              borderRadius: BorderRadius.circular(32),
                             ),
-                            textStyle: const TextStyle(color: AppColors.lightFontColor),
-                            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                            textStyle: const TextStyle(
+                                color: AppColors.lightFontColor),
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 12, horizontal: 16),
                           ),
                           onPressed: () => _loginPress(context),
                           child: Text(
                             R.current.login,
-                            style: const TextStyle(
-                              fontSize: 16,
-                            ),
+                            style: const TextStyle(fontSize: 16),
                           ),
                         ),
                       ),
@@ -255,7 +247,8 @@ class _LoginScreenState extends State<LoginScreen> {
             width: double.infinity,
             height: MediaQuery.of(context).size.height * 0.4,
             decoration: const BoxDecoration(
-              gradient: LinearGradient(colors: [Color(0x222196f3), Color(0x2203a9f4)]),
+              gradient: LinearGradient(
+                  colors: [Color(0x222196f3), Color(0x2203a9f4)]),
             ),
             child: Column(),
           ),
@@ -282,11 +275,13 @@ class WaveClipper1 extends CustomClipper<Path> {
 
     var firstEndPoint = Offset(size.width * 0.6, size.height - 29 - 50);
     var firstControlPoint = Offset(size.width * .25, size.height - 60 - 50);
-    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy, firstEndPoint.dx, firstEndPoint.dy);
+    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy,
+        firstEndPoint.dx, firstEndPoint.dy);
 
     var secondEndPoint = Offset(size.width, size.height - 60);
     var secondControlPoint = Offset(size.width * 0.84, size.height - 50);
-    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy, secondEndPoint.dx, secondEndPoint.dy);
+    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy,
+        secondEndPoint.dx, secondEndPoint.dy);
     path.lineTo(size.width, size.height);
     path.lineTo(size.width, 0);
     path.close();
@@ -307,11 +302,13 @@ class WaveClipper2 extends CustomClipper<Path> {
 
     var firstEndPoint = Offset(size.width * 0.6, size.height - 15 - 50);
     var firstControlPoint = Offset(size.width * .25, size.height - 60 - 50);
-    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy, firstEndPoint.dx, firstEndPoint.dy);
+    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy,
+        firstEndPoint.dx, firstEndPoint.dy);
 
     var secondEndPoint = Offset(size.width, size.height - 40);
     var secondControlPoint = Offset(size.width * 0.84, size.height - 30);
-    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy, secondEndPoint.dx, secondEndPoint.dy);
+    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy,
+        secondEndPoint.dx, secondEndPoint.dy);
     path.lineTo(size.width, size.height);
     path.lineTo(size.width, 0);
     path.close();
@@ -332,11 +329,13 @@ class WaveClipper3 extends CustomClipper<Path> {
 
     var firstEndPoint = Offset(size.width * .7, size.height - 40);
     var firstControlPoint = Offset(size.width * .25, size.height);
-    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy, firstEndPoint.dx, firstEndPoint.dy);
+    path.quadraticBezierTo(firstControlPoint.dx, firstControlPoint.dy,
+        firstEndPoint.dx, firstEndPoint.dy);
 
     var secondEndPoint = Offset(size.width, size.height - 45);
     var secondControlPoint = Offset(size.width * 0.84, size.height - 50);
-    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy, secondEndPoint.dx, secondEndPoint.dy);
+    path.quadraticBezierTo(secondControlPoint.dx, secondControlPoint.dy,
+        secondEndPoint.dx, secondEndPoint.dy);
     path.lineTo(size.width, size.height);
     path.lineTo(size.width, 0);
     path.close();

--- a/lib/ui/screen/login_screen.dart
+++ b/lib/ui/screen/login_screen.dart
@@ -1,6 +1,7 @@
 // TODO: remove sdk version selector after migrating to null-safety.
 // @dart=2.10
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_app/src/config/app_colors.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/src/store/local_storage.dart';
@@ -85,121 +86,126 @@ class _LoginScreenState extends State<LoginScreen> {
               padding: const EdgeInsets.all(32),
               child: Form(
                 key: _formKey,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Material(
-                      elevation: 2,
-                      borderRadius: const BorderRadius.all(Radius.circular(32)),
-                      child: TextFormField(
-                        controller: _accountControl,
-                        cursorColor: Colors.blue[800],
-                        textInputAction: TextInputAction.done,
-                        focusNode: _accountFocus,
-                        onEditingComplete: () {
-                          _accountFocus.unfocus();
-                          FocusScope.of(context).requestFocus(_passwordFocus);
-                        },
-                        validator: (value) => _validatorAccount(value),
-                        decoration: InputDecoration(
-                          hintText: R.current.account,
-                          errorStyle: const TextStyle(
-                            height: 0,
-                            fontSize: 0,
-                          ),
-                          prefixIcon: const Icon(
-                            Icons.account_circle,
-                            color: Colors.grey,
-                          ),
-                          border: InputBorder.none,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(
-                      height: 4,
-                    ),
-                    if (_accountErrorMessage.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.only(left: 16),
-                        child: Text(
-                          _accountErrorMessage,
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: Colors.red,
+                child: AutofillGroup(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Material(
+                        elevation: 2,
+                        borderRadius: const BorderRadius.all(Radius.circular(32)),
+                        child: TextFormField(
+                          controller: _accountControl,
+                          cursorColor: Colors.blue[800],
+                          textInputAction: TextInputAction.next,
+                          focusNode: _accountFocus,
+                          autofillHints: const [AutofillHints.username],
+                          onEditingComplete: () {
+                            _accountFocus.unfocus();
+                            FocusScope.of(context).requestFocus(_passwordFocus);
+                          },
+                          validator: (value) => _validatorAccount(value),
+                          decoration: InputDecoration(
+                            hintText: R.current.account,
+                            errorStyle: const TextStyle(
+                              height: 0,
+                              fontSize: 0,
+                            ),
+                            prefixIcon: const Icon(
+                              Icons.account_circle,
+                              color: Colors.grey,
+                            ),
+                            border: InputBorder.none,
                           ),
                         ),
                       ),
-                    const SizedBox(
-                      height: 20,
-                    ),
-                    Material(
-                      elevation: 2,
-                      borderRadius: const BorderRadius.all(Radius.circular(32)),
-                      child: TextFormField(
-                        controller: _passwordControl,
-                        cursorColor: Colors.blue[800],
-                        obscureText: true,
-                        focusNode: _passwordFocus,
-                        onEditingComplete: () {
-                          _passwordFocus.unfocus();
-                        },
-                        validator: (value) => _validatorPassword(value),
-                        decoration: InputDecoration(
-                          hintText: R.current.password,
-                          errorStyle: const TextStyle(
-                            height: 0,
-                            fontSize: 0,
+                      const SizedBox(
+                        height: 4,
+                      ),
+                      if (_accountErrorMessage.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(left: 16),
+                          child: Text(
+                            _accountErrorMessage,
+                            style: const TextStyle(
+                              fontSize: 12,
+                              color: Colors.red,
+                            ),
                           ),
-                          prefixIcon: const Icon(
-                            Icons.lock,
-                            color: Colors.grey,
-                          ),
-                          border: InputBorder.none,
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 25,
-                            vertical: 13,
+                        ),
+                      const SizedBox(
+                        height: 20,
+                      ),
+                      Material(
+                        elevation: 2,
+                        borderRadius: const BorderRadius.all(Radius.circular(32)),
+                        child: TextFormField(
+                          controller: _passwordControl,
+                          cursorColor: Colors.blue[800],
+                          obscureText: true,
+                          focusNode: _passwordFocus,
+                          autofillHints: const [AutofillHints.password],
+                          onEditingComplete: () {
+                            _passwordFocus.unfocus();
+                            TextInput.finishAutofillContext();
+                          },
+                          validator: (value) => _validatorPassword(value),
+                          decoration: InputDecoration(
+                            hintText: R.current.password,
+                            errorStyle: const TextStyle(
+                              height: 0,
+                              fontSize: 0,
+                            ),
+                            prefixIcon: const Icon(
+                              Icons.lock,
+                              color: Colors.grey,
+                            ),
+                            border: InputBorder.none,
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 25,
+                              vertical: 13,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    const SizedBox(
-                      height: 4,
-                    ),
-                    if (_passwordErrorMessage.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.only(left: 16),
-                        child: Text(
-                          _passwordErrorMessage,
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: Colors.red,
+                      const SizedBox(
+                        height: 4,
+                      ),
+                      if (_passwordErrorMessage.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(left: 16),
+                          child: Text(
+                            _passwordErrorMessage,
+                            style: const TextStyle(
+                              fontSize: 12,
+                              color: Colors.red,
+                            ),
+                          ),
+                        ),
+                      const SizedBox(
+                        height: 25,
+                      ),
+                      Align(
+                        alignment: Alignment.center,
+                        child: TextButton(
+                          style: TextButton.styleFrom(
+                            foregroundColor: AppColors.mainColor,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(32.0),
+                            ),
+                            textStyle: const TextStyle(color: AppColors.lightFontColor),
+                            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                          ),
+                          onPressed: () => _loginPress(context),
+                          child: Text(
+                            R.current.login,
+                            style: const TextStyle(
+                              fontSize: 16,
+                            ),
                           ),
                         ),
                       ),
-                    const SizedBox(
-                      height: 25,
-                    ),
-                    Align(
-                      alignment: Alignment.center,
-                      child: TextButton(
-                        style: TextButton.styleFrom(
-                          foregroundColor: AppColors.mainColor,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(32.0),
-                          ),
-                          textStyle: const TextStyle(color: AppColors.lightFontColor),
-                          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-                        ),
-                        onPressed: () => _loginPress(context),
-                        child: Text(
-                          R.current.login,
-                          style: const TextStyle(
-                            fontSize: 16,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->
- This PR causes the username and password fields of the login screen to trigger autofill, improving the UX of password manager users.
- The Column widget gets wrapped with the AutofillGroup widget.

## How to Verify? <!-- btsbot.attachSection(<<##) -->
- Prepare an password manager, e.g. KeepassXC2Android or Google Passwords
- Launch the app logged out
- Click on either username or password field triggers the autofill prompt.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->

<img src="https://user-images.githubusercontent.com/53939195/228455850-ef6d0f00-665d-45b0-b46c-7a44b914f77e.png" alt="username" width="200" />
<img src="https://user-images.githubusercontent.com/53939195/228456694-1d99470a-f759-4e31-a120-ed912718b47f.png" alt="password" width="200" />
