### PR TITLE
Enhancement #170: Change the tab selected style in score calculation page.

### DIFF
--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -247,7 +247,7 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
               controller: _tabController,
               labelColor: AppColors.mainColor,
               unselectedLabelColor: Colors.white,
-              indicatorSize: TabBarIndicatorSize.label,
+              indicatorSize: TabBarIndicatorSize.tab,
               indicator: BoxDecoration(
                 borderRadius: const BorderRadius.only(
                   topLeft: Radius.circular(10),


### PR DESCRIPTION
Change the margin of the tabs on the top in score calculation page.
- 
Origin:
![](https://user-images.githubusercontent.com/55730003/219867675-8cc7be47-aa94-490d-b3d6-c85c27beaa2a.jpg)
![](https://user-images.githubusercontent.com/55730003/219867687-714209d1-3469-41d5-ab20-110c35856f2b.jpg)
Now:
![Screenshot_20230401_214901](https://user-images.githubusercontent.com/35259118/229293062-200fbcdb-c816-4fa8-9202-9a9d9f6d09ec.png)

