### PR TITLE
Fix: Reload error happened on zh-tw course information page

### DIFF
--- a/lib/src/connector/course_connector.dart
+++ b/lib/src/connector/course_connector.dart
@@ -332,10 +332,10 @@ class CourseConnector {
         courseMain.stage = nodesOne[2].text.replaceAll("\n", ""); //階段
         courseMain.credits = nodesOne[3].text.replaceAll("\n", ""); //學分
         courseMain.hours = nodesOne[4].text.replaceAll("\n", ""); //時數
-        courseMain.note = nodesOne[20].text.replaceAll("\n", ""); //備註
-        if (nodesOne[19].getElementsByTagName("a").isNotEmpty) {
+        courseMain.note = nodesOne[19].text.replaceAll("\n", ""); //備註
+        if (nodesOne[18].getElementsByTagName("a").isNotEmpty) {
           courseMain.scheduleHref =
-              _courseCNHost + nodesOne[19].getElementsByTagName("a")[0].attributes["href"]; //教學進度大綱
+              _courseCNHost + nodesOne[18].getElementsByTagName("a")[0].attributes["href"]; //教學進度大綱
         }
 
         //時間


### PR DESCRIPTION
## Description <!-- btsbot.attachSection(<<##) -->

See: #203 

Fix the issue by changed the index:

 - Note should be 19.
 - ScheduleHref should be 18.

## How to Verify? <!-- btsbot.attachSection(<<##) -->

 - [x] Check the error message won't happen on application w/ zh-TW language.
 - [x] Check the error message won't happen on application w/ en-US language.
 - [x] Check the index should be correct.

## Screenshots/GIF/Test Results (Optional) <!-- btsbot.attachSection(<<##) -->

<img width="841" alt="image" src="https://github.com/NEO-TAT/tat_flutter/assets/69747731/ed49978c-9489-4086-816a-8951ed5fbf9f">

<img width="444" alt="image" src="https://github.com/NEO-TAT/tat_flutter/assets/69747731/78ef6e47-badb-4127-aee5-29652c62165c">

<img width="423" alt="image" src="https://github.com/NEO-TAT/tat_flutter/assets/69747731/fde22ef3-a309-4f61-9abe-069c32b9045c">

