### PR TITLE
修復「更新跳轉出現異常」

### DIFF
--- a/lib/src/version/update/app_update.dart
+++ b/lib/src/version/update/app_update.dart
@@ -85,7 +85,7 @@ class AppUpdate {
   static void _openAppStore() async {
     final url = AppLink.storeUrlString;
     if (await canLaunchUrl(Uri.parse(url))) {
-      await launchUrl(Uri.parse(url), mode:LaunchMode.externalApplication);
+      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
     }
   }
 }

--- a/lib/src/version/update/app_update.dart
+++ b/lib/src/version/update/app_update.dart
@@ -85,7 +85,7 @@ class AppUpdate {
   static void _openAppStore() async {
     final url = AppLink.storeUrlString;
     if (await canLaunchUrl(Uri.parse(url))) {
-      await canLaunchUrl(Uri.parse(url));
+      await launchUrl(Uri.parse(url), mode:LaunchMode.externalApplication);
     }
   }
 }


### PR DESCRIPTION
## Description

Close: #210 and #175 

在這個 PR 中，我修復了 iPhone12/iOS17 更新跳轉出現異常的問題。

在版本強制更新的 Modal 中，若點擊更新時會導致跳轉出現異常並使應用程式關閉。

在這個版本上我使用 `launchUrl` 與 `LaunchMode` 來取代 `canLaunchUrl`，問題已解決。

## Implementation

- [x] 使用 `launchUrl` 與 `LaunchMode` 來取代 `canLaunchUrl`

## Testing Instructions

> **Warning**
> 由於模擬器並沒有 AppStore，你會需要實體的 iOS 裝置來進行測試。

> **NOTE**
> 你可以安裝 v1.4.5 版本，但請使用 Beta Flavor 進行測試，即 1.4.48763 的假更新消息（但強制更新）。

- [x] 測試進入「強制更新」頁面時，點擊「更新」時不會出現崩潰。
- [x] 測試進入「強制更新」頁面時，點擊「更新」時能夠正確跳轉到 AppStore 的頁面上。