### PR TITLE
fix: allow characters in student ID when matching for studentSemester…

### DIFF
--- a/lib/src/connector/course_connector.dart
+++ b/lib/src/connector/course_connector.dart
@@ -107,7 +107,7 @@ class CourseConnector {
       // e.g. "學號：110310144　　姓名：xxx　　班級：電機三甲　　　 112 學年度 第 1 學期　上課時間表"
       // so the RegExp is used to filter out only the number parts
       final titleString = nodes[0].text;
-      final RegExp studentSemesterDetailFilter = RegExp(r'\b\d+\b');
+      final RegExp studentSemesterDetailFilter = RegExp(r'\b[\dA-Z]+\b');
       final Iterable<RegExpMatch> studentSemesterDetailMatches = studentSemesterDetailFilter.allMatches(titleString);
       // "studentSemesterDetails" should consist of three numerical values
       // ex: [110310144, 112, 1]


### PR DESCRIPTION
## Description

Fixes the problem where an `RangeError` is thown when the student ID contains alphabets caused by the changes in 8a6b8888ccac1279a54598fd65f2391822c9a9dd.

## Implementation

- [x] Update the RegExp to match all uppercase characters and numbers, i.e. `[\dA-Z]+`.

## Testing Instructions

- [x] Test if the `studentSemesterDetails` list has correctly matched items:
    - [x] In an account with an ID containing only numbers (e.g. 111360109)
    - [x] In an account with an ID containing alphabets (e.g. 1112B0024)

## Additional Notes

Special thanks to @umeow0716 for finding this bug and its root cause. 
