### PR TITLE
Optimize Category

### DIFF
--- a/lib/src/connector/score_connector.dart
+++ b/lib/src/connector/score_connector.dart
@@ -115,6 +115,7 @@ class ScoreConnector {
           scoreNode = scoreNodes[j];
           CourseScoreInfoJson score = CourseScoreInfoJson();
           score.courseId = scoreNode.getElementsByTagName("th")[0].text.replaceAll(RegExp(r"[\s| ]"), "");
+          score.category = scoreNode.getElementsByTagName("th")[1].text[0];
           score.nameZh = scoreNode.getElementsByTagName("th")[2].text.replaceAll(RegExp(r"[\s| ]"), "");
           score.nameEn = scoreNode.getElementsByTagName("th")[3].text.replaceAll(RegExp("\n"), "");
           RegExp creditDoubleFilter = RegExp(r'\d+(\.\d+)?');
@@ -141,7 +142,7 @@ class ScoreConnector {
 
       parameter = ConnectorParameter(_scoreRankUrl);
       parameter.data = data;
-      parameter.charsetName = "big5";
+      parameter.charsetName = "utf-8";
       result = await Connector.getDataByGet(parameter);
       tagNode = parse(result);
       final rankNodes = tagNode

--- a/lib/ui/pages/score/course_score_section.dart
+++ b/lib/ui/pages/score/course_score_section.dart
@@ -14,10 +14,6 @@ class CourseScoreSection extends StatelessWidget {
 
   final List<CourseScoreInfoJson> _scoreInfoList;
 
-  void _onCategoryChanged(int? category) {
-    // TODO(TU): implement this method in view model or controller.
-  }
-
   @override
   Widget build(BuildContext context) => Column(
         children: [
@@ -34,7 +30,6 @@ class CourseScoreSection extends StatelessWidget {
                   courseName: scoreInfo.name,
                   category: scoreInfo.category,
                   scoreValue: scoreInfo.score,
-                  onCategoryChanged: _onCategoryChanged,
                 ),
               );
             },

--- a/lib/ui/pages/score/score_page.dart
+++ b/lib/ui/pages/score/score_page.dart
@@ -7,12 +7,9 @@ import 'package:flutter_app/src/model/course/course_score_json.dart';
 import 'package:flutter_app/src/providers/app_provider.dart';
 import 'package:flutter_app/src/r.dart';
 import 'package:flutter_app/src/store/local_storage.dart';
-import 'package:flutter_app/src/task/course/course_extra_info_task.dart';
 import 'package:flutter_app/src/task/score/score_rank_task.dart';
 import 'package:flutter_app/src/task/task_flow.dart';
 import 'package:flutter_app/ui/other/app_expansion_tile.dart';
-import 'package:flutter_app/ui/other/my_toast.dart';
-import 'package:flutter_app/ui/other/progress_rate_dialog.dart';
 import 'package:flutter_app/ui/pages/score/app_bar_action_buttons.dart';
 import 'package:flutter_app/ui/pages/score/course_score_section.dart';
 import 'package:flutter_app/ui/pages/score/graduation_picker.dart';
@@ -160,47 +157,6 @@ class _ScoreViewerPageState extends State<ScoreViewerPage> with TickerProviderSt
       courseScoreList
         ..clear()
         ..addAll(scoreTask.result ?? const []);
-    }
-
-    if (courseScoreList.isNotEmpty) {
-      await LocalStorage.instance.setSemesterCourseScore(courseScoreList);
-      int total = courseScoreCredit.getCourseInfoList().length;
-      final courseInfoList = courseScoreCredit.getCourseInfoList();
-      // ignore: use_build_context_synchronously
-      final progressRateDialog = ProgressRateDialog(context);
-
-      progressRateDialog.update(message: R.current.searchingCredit, nowProgress: 0, progressString: "0/0");
-      progressRateDialog.show();
-
-      for (int i = 0; i < total; i++) {
-        final courseInfo = courseInfoList[i];
-        final courseId = courseInfo.courseId;
-        if (courseInfo.category.isEmpty) {
-          final task = CourseExtraInfoTask(courseId);
-          task.openLoadingDialog = false;
-          if (courseId.isNotEmpty) {
-            taskFlow.addTask(task);
-          }
-        }
-      }
-
-      total = taskFlow.length;
-      int rate = 0;
-
-      taskFlow.callback = (task) {
-        rate++;
-        progressRateDialog.update(nowProgress: rate / total, progressString: sprintf("%d/%d", [rate, total]));
-        final extraInfo = task.result;
-        final courseScoreInfo = courseScoreCredit.getCourseByCourseId(extraInfo.course.id);
-        courseScoreInfo.category = extraInfo.course.category;
-        courseScoreInfo.openClass = extraInfo.course.openClass.replaceAll("\n", " ");
-      };
-
-      await taskFlow.start();
-      await LocalStorage.instance.setSemesterCourseScore(courseScoreList);
-      progressRateDialog.hide();
-    } else {
-      MyToast.show(R.current.searchCreditIsNullWarning);
     }
 
     _buildTabBar();

--- a/lib/ui/pages/score/widgets/score_tile_widget.dart
+++ b/lib/ui/pages/score/widgets/score_tile_widget.dart
@@ -2,56 +2,28 @@
 
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_app/src/model/course/course_score_json.dart';
 
 typedef OnCategoryChanged = void Function(int? category);
 
 class ScoreTile extends StatelessWidget {
-  ScoreTile({
+  const ScoreTile({
     super.key,
     required String courseName,
     required String category,
-    required String scoreValue,
-    OnCategoryChanged? onCategoryChanged,
+    required String scoreValue
   })  : _courseName = courseName,
         _category = category,
-        _scoreValue = scoreValue,
-        _onCategoryChanged = onCategoryChanged;
+        _scoreValue = scoreValue;
 
   /// The score value of a course.
   /// Note that we should make the score's type to be a [String] instead of [int] since the score can be a string like "Q".
   final String _scoreValue;
   final String _category;
   final String _courseName;
-  final OnCategoryChanged? _onCategoryChanged;
-
-  final ValueNotifier<int?> _selectedCategory = ValueNotifier(null);
-
-  int? _getInitialCategoryIndex() {
-    final index = constCourseType.indexOf(_category);
-    return index == -1 ? null : index;
-  }
 
   Widget get _courseNameText => AutoSizeText(
         _courseName,
         style: const TextStyle(fontSize: 16.0),
-      );
-
-  Widget get _categoryMenu => ValueListenableBuilder(
-        valueListenable: _selectedCategory,
-        builder: (_, value, __) => DropdownButton(
-          underline: const SizedBox.shrink(),
-          value: value ?? _getInitialCategoryIndex(),
-          items: constCourseType
-              .asMap()
-              .entries
-              .map((category) => _buildCategoryMenuItem(category.value, category.key))
-              .toList(),
-          onChanged: (newCategory) {
-            _selectedCategory.value = newCategory;
-            _onCategoryChanged?.call(newCategory);
-          },
-        ),
       );
 
   Widget get _scoreValueText => SizedBox(
@@ -63,20 +35,21 @@ class ScoreTile extends StatelessWidget {
         ),
       );
 
-  DropdownMenuItem<int> _buildCategoryMenuItem(String category, int index) => DropdownMenuItem(
-        value: index,
-        child: Text(
-          category,
-          style: const TextStyle(fontSize: 16.0),
-        ),
-      );
+  Widget get _categoryValueText => SizedBox(
+    width: 40,
+    child: Text(
+      _category,
+      style: const TextStyle(fontSize: 16.0),
+      textAlign: TextAlign.center,
+    ),
+  );
 
   @override
   Widget build(BuildContext context) => Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Expanded(child: _courseNameText),
-          if (_category.isNotEmpty) _categoryMenu,
+          _categoryValueText,
           _scoreValueText,
         ],
       );

--- a/lib/ui/pages/score/widgets/score_tile_widget.dart
+++ b/lib/ui/pages/score/widgets/score_tile_widget.dart
@@ -6,12 +6,8 @@ import 'package:flutter/material.dart';
 typedef OnCategoryChanged = void Function(int? category);
 
 class ScoreTile extends StatelessWidget {
-  const ScoreTile({
-    super.key,
-    required String courseName,
-    required String category,
-    required String scoreValue
-  })  : _courseName = courseName,
+  const ScoreTile({super.key, required String courseName, required String category, required String scoreValue})
+      : _courseName = courseName,
         _category = category,
         _scoreValue = scoreValue;
 
@@ -36,13 +32,13 @@ class ScoreTile extends StatelessWidget {
       );
 
   Widget get _categoryValueText => SizedBox(
-    width: 40,
-    child: Text(
-      _category,
-      style: const TextStyle(fontSize: 16.0),
-      textAlign: TextAlign.center,
-    ),
-  );
+        width: 40,
+        child: Text(
+          _category,
+          style: const TextStyle(fontSize: 16.0),
+          textAlign: TextAlign.center,
+        ),
+      );
 
   @override
   Widget build(BuildContext context) => Row(


### PR DESCRIPTION
## Description

In this PR, I optimize the category loading when fetching the score.

In the previous discussion, the symbol category caused huge loading time and treat as meaningless. 
Therefore, in this PR, we optimized the category by present it "必" or "選“ instead of symbol category "▲" or "★".  

## Testing Instructions

- [x] Check the category in the score page is shown correctly.
