### PR TITLE
修復「誤用 null courseMainInfo」的問題

### DIFF
--- a/lib/src/connector/ischool_plus_connector.dart
+++ b/lib/src/connector/ischool_plus_connector.dart
@@ -117,7 +117,7 @@ class ISchoolPlusConnector {
   static Future<ReturnWithStatus<List<CourseStudent>>> getCourseStudent(String courseId) async {
     try {
       if (!await _selectCourse(courseId)) {
-        final returnResult = ReturnWithStatus();
+        final returnResult = ReturnWithStatus<List<CourseStudent>>();
         returnResult.status = IPlusReturnStatus.noPermission;
         return returnResult;
       }
@@ -155,7 +155,7 @@ class ISchoolPlusConnector {
       return returnResult;
     } catch (e, stack) {
       Log.eWithStack(e, stack);
-      final returnResult = ReturnWithStatus();
+      final returnResult = ReturnWithStatus<List<CourseStudent>>();
       returnResult.status = IPlusReturnStatus.fail;
       return returnResult;
     }

--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -42,10 +42,10 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
     super.initState();
     isLoading = true;
     BackButtonInterceptor.add(myInterceptor);
+    Future.microtask(() => _loadCourseStudent());
     Future.delayed(Duration.zero, () {
       _addTask();
     });
-    Future.microtask(() => _loadCourseStudent());
   }
 
   @override

--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -42,10 +42,10 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
     super.initState();
     isLoading = true;
     BackButtonInterceptor.add(myInterceptor);
-    Future.microtask(() => _loadCourseStudent());
     Future.delayed(Duration.zero, () {
       _addTask();
     });
+    Future.microtask(() => _loadCourseStudent());
   }
 
   @override
@@ -229,6 +229,7 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
 
   void _loadCourseStudent() async {
     TaskFlow taskFlow = TaskFlow();
+    final courseMainInfo = widget.courseInfo.main;
     final task = IPlusGetStudentListTask(courseId: courseMainInfo.course.id);
     taskFlow.addTask(task);
     if (await taskFlow.start()) {

--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -202,6 +202,7 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
 
   Future<List<CourseStudent>> _getCourseStudent() async {
     TaskFlow taskFlow = TaskFlow();
+    final courseMainInfo = widget.courseInfo.main;
     final task = IPlusGetStudentListTask(courseId: courseMainInfo.course.id);
     taskFlow.addTask(task);
     if (await taskFlow.start()) {


### PR DESCRIPTION
## Description

在這個 PR 上修復了誤用 global courseMainInfo 的問題，可能導致以下的 exception 不停觸發。

```
I/flutter (22396): ----------------FIREBASE CRASHLYTICS----------------
I/flutter (22396): NoSuchMethodError: The getter 'course' was called on null.
I/flutter (22396): Receiver: null
I/flutter (22396): Tried calling: course
I/flutter (22396): #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
I/flutter (22396): #1      _CourseInfoPageState._loadCourseStudent (package:flutter_app/ui/pages/coursedetail/screen/course_info_page.dart:232:67)
I/flutter (22396): #2      _CourseInfoPageState.initState.<anonymous closure> (package:flutter_app/ui/pages/coursedetail/screen/course_info_page.dart:48:28)
I/flutter (22396): #3      new Future.microtask.<anonymous closure> (dart:async/future.dart:277:37)
I/flutter (22396): #4      _rootRun (dart:async/zone.dart:1390:47)
I/flutter (22396): #5      _CustomZone.run (dart:async/zone.dart:1300:19)
I/flutter (22396): #6      _CustomZone.runGuarded (dart:async/zone.dart:1208:7)
I/flutter (22396): #7      _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1248:23)
I/flutter (22396): #8      _rootRun (dart:async/zone.dart:1398:13)
I/flutter (22396): #9      _CustomZone.run (dart:async/zone.dart:1300:19)
I/flutter (22396): #10     _CustomZone.runGuarded (dart:async/zone.dart:1208:7)
I/flutter (22396): #11     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1248:23)
I/flutter (22396): #12     _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
I/flutter (22396): #13     _startMicrotaskLoop (d
I/flutter (22396): ----------------------------------------------------
```

修復成使用 `widget` 的值，見 Files Changed。

## How to review it?

 - [x] 確保每一次點入課程後不會出現以上的 exception。