### PR TITLE
回復「修課人數」並且新增「學生清單」標題

### DIFF
--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -70,6 +70,9 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
       courseExtraInfo = task.result;
     }
     widget.courseInfo.extra = courseExtraInfo;
+    List<CourseStudent> students = await _getCourseStudent();
+    Map<String, String> departmentMap = await _getCourseDepartmentMap();
+
     courseData.add(_buildCourseInfo(sprintf("%s: %s", [R.current.courseId, courseMainInfo.course.id])));
     courseData.add(_buildCourseInfo(sprintf("%s: %s", [R.current.courseName, courseMainInfo.course.name])));
     courseData.add(_buildCourseInfo(sprintf("%s: %s    ", [R.current.credit, courseMainInfo.course.credits])));
@@ -88,15 +91,17 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
       courseMainInfo.getClassroomNameList(),
       courseMainInfo.getClassroomHrefList(),
     ));
+    courseData.add(_buildCourseInfo(sprintf("%s: %s", [R.current.numberOfStudent, students.length])));
 
     listItem.removeRange(0, listItem.length);
     listItem.add(_buildInfoTitle(R.current.courseData));
     listItem.addAll(courseData);
 
-    List<CourseStudent> students = await _getCourseStudent();
-    Map<String, String> departmentMap = await _getCourseDepartmentMap();
+
 
     if (students.isNotEmpty) {
+      listItem.add(_buildInfoTitle(""));
+      listItem.add(_buildInfoTitle(R.current.studentList));
       listItem.add(
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 0),

--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -70,8 +70,8 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
       courseExtraInfo = task.result;
     }
     widget.courseInfo.extra = courseExtraInfo;
-    List<CourseStudent> students = await _getCourseStudent();
-    Map<String, String> departmentMap = await _getCourseDepartmentMap();
+    final List<CourseStudent> students = await _getCourseStudent();
+    final Map<String, String> departmentMap = await _getCourseDepartmentMap();
 
     courseData.add(_buildCourseInfo(sprintf("%s: %s", [R.current.courseId, courseMainInfo.course.id])));
     courseData.add(_buildCourseInfo(sprintf("%s: %s", [R.current.courseName, courseMainInfo.course.name])));

--- a/lib/ui/pages/coursedetail/screen/course_info_page.dart
+++ b/lib/ui/pages/coursedetail/screen/course_info_page.dart
@@ -97,8 +97,6 @@ class _CourseInfoPageState extends State<CourseInfoPage> with AutomaticKeepAlive
     listItem.add(_buildInfoTitle(R.current.courseData));
     listItem.addAll(courseData);
 
-
-
     if (students.isNotEmpty) {
       listItem.add(_buildInfoTitle(""));
       listItem.add(_buildInfoTitle(R.current.studentList));


### PR DESCRIPTION
## Description

在這個 PR 中，我回復了修課人數並且新增學生清單標題。

<img width="311" alt="image" src="https://github.com/NEO-TAT/tat_flutter/assets/69747731/13e5c8d6-e9a6-4ea7-9fa0-7011a5038365">

用於顯示目前的修課人數，並且回復學生清單的標題，並在兩個不同的列表中插一個空白來進行區隔。

## How to review it

 - [x] 確認畫面正常顯示無誤。