### PR TITLE
chore: apply diffs generated by Flutter 3.7.12 during build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,6 +37,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "club.ntut.npc.tat"
     compileSdkVersion 34
+    ndkVersion "25.1.8937393"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## Description

This PR addresses the diffs generated in the Gradle configuration files after building the project. The following updates were applied to ensure compatibility with the build environment:
- Added `ndkVersion` to `android/app/build.gradle`.
- Updated `clean` task syntax in `android/build.gradle` to use `tasks.register` as recommended by newer Gradle versions.

## Implementation

- [x] Added `ndkVersion "25.1.8937393"` to `android/app/build.gradle` for NDK compatibility.
- [x] Updated `task clean` to `tasks.register("clean")` in `android/build.gradle`.

## Testing Instructions

Please follow these steps to review and test the PR:
1. Ensure the project builds successfully after these changes.
2. Validate that the changes to `build.gradle` files persist across builds without generating new diffs.
3. Perform manual testing to verify:
   - Compatibility with the specified NDK version.
   - Build tasks execute as expected.